### PR TITLE
fix: use %USERPROFILE% in Windows autostart VBS for non-ASCII homes

### DIFF
--- a/src/autostart.mjs
+++ b/src/autostart.mjs
@@ -84,7 +84,17 @@ WantedBy=default.target
 
 // The task runs wscript.exe on this one-liner so no console window flashes at
 // logon; cmd routes stdout/stderr into the regular server.log.
-export function buildWindowsVbs({ nodePath, cliPath, port, logPath }) {
-  const cmd = `cmd /c ""${nodePath}" "${cliPath}" serve --port ${port} >> "${logPath}" 2>&1"`;
+export function buildWindowsVbs({ nodePath, cliPath, port, logPath, homeDir = homedir() }) {
+  // wscript reads .vbs files as ANSI (GBK on zh-CN systems), so a literal log
+  // path containing a non-ASCII user name becomes mojibake and cmd cannot open
+  // it. Redirect through %USERPROFILE% (expanded by cmd at runtime) instead.
+  let log = logPath;
+  const homePrefix = homeDir.replace(/[\\/]+$/, "");
+  const lowerLog = logPath.toLowerCase();
+  const lowerHome = homePrefix.toLowerCase();
+  if (lowerLog.startsWith(`${lowerHome}\\`) || lowerLog.startsWith(`${lowerHome}/`)) {
+    log = `%USERPROFILE%${logPath.slice(homePrefix.length)}`;
+  }
+  const cmd = `cmd /c ""${nodePath}" "${cliPath}" serve --port ${port} >> "${log}" 2>&1"`;
   return `CreateObject("Wscript.Shell").Run "${cmd.replaceAll('"', '""')}", 0, False\r\n`;
 }

--- a/test/autostart.test.mjs
+++ b/test/autostart.test.mjs
@@ -67,6 +67,29 @@ test("windows vbs hides the console and appends to the router log", () => {
   assert.ok(vbs.trimEnd().endsWith(", 0, False"));
 });
 
+test("windows vbs rewrites home-relative log paths to %USERPROFILE% for non-ASCII homes", () => {
+  const vbs = buildWindowsVbs({
+    nodePath: "C:\\Program Files\\nodejs\\node.exe",
+    cliPath: "C:\\x\\src\\cli.mjs",
+    port: 10110,
+    logPath: "C:\\Users\\王小明\\.codex\\dscodex\\server.log",
+    homeDir: "C:\\Users\\王小明",
+  });
+  assert.ok(vbs.includes('>> ""%USERPROFILE%\\.codex\\dscodex\\server.log"" 2>&1'));
+  assert.equal(vbs.match(/[^\x00-\x7F]/g), null);
+});
+
+test("windows vbs keeps literal log paths outside the user home", () => {
+  const vbs = buildWindowsVbs({
+    nodePath: "C:\\Program Files\\nodejs\\node.exe",
+    cliPath: "C:\\x\\src\\cli.mjs",
+    port: 10110,
+    logPath: "D:\\logs\\server.log",
+    homeDir: "C:\\Users\\王小明",
+  });
+  assert.ok(vbs.includes('>> ""D:\\logs\\server.log"" 2>&1'));
+});
+
 test("serve owns its pid file across start and graceful shutdown", { timeout: 20_000 }, async () => {
   const codexHome = mkdtempSync(join(tmpdir(), "dscodex-serve-"));
   const port = 20_000 + Math.floor(Math.random() * 20_000);


### PR DESCRIPTION
## 问题

在中文等非 ASCII 用户名的 Windows 系统（如 `C:\Users\张三`）上，`dscodex autostart enable` 会把 `~/.codex/dscodex/server.log` 的完整路径以 UTF-8 字面量写入 `autostart-run.vbs`。wscript 按 ANSI（中文系统为 GBK）读取 .vbs 文件，路径变成乱码，`cmd /c` 找不到日志文件，路由进程不会启动，最终报错 `Autostart is installed but the router did not become ready`。

## 修复

- `buildWindowsVbs` 检测日志路径是否位于用户主目录下；若是，改为输出 `%USERPROFILE%\.codex\dscodex\server.log`，由 cmd 在运行时展开环境变量，彻底避开非 ASCII 用户名写入 VBS 的编码问题。
- 新增可选参数 `homeDir`（默认 `os.homedir()`），与 `launchdPlistPath` / `systemdUnitPath` 的既有风格一致，便于测试。
- 新增两个单测：非 ASCII 主目录下的日志路径被重写为 `%USERPROFILE%` 且输出保持纯 ASCII；主目录之外的日志路径保持原样。

## 验证

- 实测复现与修复：中文用户名 + 旧代码 → autostart 后路由未就绪；修复后任务计划 `Last Result 0`，路由正常启动，`dscodex doctor` 五项全 ok。
- `npm test`：新增用例通过；POSIX 上全绿。Windows 上唯一的失败是既有的 `keys.test.mjs` 权限位断言（POSIX mode bit 在 Windows 不生效），与本次改动无关。
