### PR TITLE
security: require client auth on loopback port and DPAPI-encrypt the DeepSeek key

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -420,7 +420,7 @@ async function manageKey(subcommand, paths, port) {
   if (subcommand === "set") {
     const key = process.env.DEEPSEEK_API_KEY?.trim() || launchctlKey() || await promptSecret("DeepSeek API Key: ");
     writeStoredKey(paths.keyFile, key);
-    console.log(`Stored DeepSeek API key in ${paths.keyFile} (mode 0600)`);
+    console.log(`Stored DeepSeek API key in ${paths.keyFile} (${process.platform === "win32" ? "DPAPI-encrypted" : "mode 0600"})`);
     if (await health(port)) console.log("Restart the router (stop && start) so the running server picks up the new key");
     return;
   }

--- a/src/keys.mjs
+++ b/src/keys.mjs
@@ -1,13 +1,36 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 const FIELD = "deepseek_api_key";
+const ENCODING_FIELD = "key_encoding";
+const DPAPI = "dpapi";
+const PLAIN = "plain";
+
+// Windows stores the key with DPAPI (CurrentUser scope) so other accounts and
+// casual file reads (backups, copies) cannot recover the plaintext. The same
+// user's router can still decrypt it at startup. Non-Windows keeps the
+// plaintext file (mode 0600) exactly as before.
+function dpapiProtect(plain) {
+  const encoded = Buffer.from(plain, "utf8").toString("base64");
+  const script = `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Protect([Convert]::FromBase64String('${encoded}'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`;
+  return execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { encoding: "utf8", windowsHide: true }).trim();
+}
+
+function dpapiUnprotect(encoded) {
+  const script = `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('${encoded}'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`;
+  const base64 = execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { encoding: "utf8", windowsHide: true }).trim();
+  return Buffer.from(base64, "base64").toString("utf8");
+}
 
 export function readStoredKey(keyFile) {
   if (!existsSync(keyFile)) return "";
   try {
     const parsed = JSON.parse(readFileSync(keyFile, "utf8"));
-    return typeof parsed?.[FIELD] === "string" ? parsed[FIELD].trim() : "";
+    const stored = typeof parsed?.[FIELD] === "string" ? parsed[FIELD].trim() : "";
+    if (!stored) return "";
+    // Legacy files written before key_encoding existed store the plaintext.
+    return parsed?.[ENCODING_FIELD] === DPAPI ? dpapiUnprotect(stored) : stored;
   } catch {
     return "";
   }
@@ -17,8 +40,10 @@ export function writeStoredKey(keyFile, key) {
   const trimmed = key.trim();
   if (!trimmed) throw new Error("Empty DeepSeek API key");
   mkdirSync(dirname(keyFile), { recursive: true, mode: 0o700 });
+  const encoding = process.platform === "win32" ? DPAPI : PLAIN;
+  const stored = encoding === DPAPI ? dpapiProtect(trimmed) : trimmed;
   const temporary = `${keyFile}.dscodex-tmp-${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ [FIELD]: trimmed }, null, 2)}\n`, { mode: 0o600 });
+  writeFileSync(temporary, `${JSON.stringify({ [FIELD]: stored, [ENCODING_FIELD]: encoding }, null, 2)}\n`, { mode: 0o600 });
   renameSync(temporary, keyFile);
 }
 

--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -162,6 +162,14 @@ export function createProxyServer({
         json(response, 503, { error: { message: "DEEPSEEK_API_KEY is not configured in the DSCodex server process" } });
         return;
       }
+      // The loopback port injects the stored DeepSeek key upstream, so it must
+      // not answer anonymous callers (browsers, sandboxed processes, or other
+      // local tools). The stock Codex client always sends its own credentials
+      // (ChatGPT OAuth or an API key), which is enough to pass this gate.
+      if (deepSeek && !request.headers.authorization?.trim()) {
+        json(response, 401, { error: { message: "Missing authorization header: the Codex client must authenticate before the local router can use the DeepSeek key" } });
+        return;
+      }
 
       let outgoingBody = raw;
       if (deepSeek) {

--- a/test/keys.test.mjs
+++ b/test/keys.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,7 +11,23 @@ test("stored key roundtrips with owner-only file permissions", () => {
   const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
   writeStoredKey(keyFile, "  sk-test-123  ");
   assert.equal(readStoredKey(keyFile), "sk-test-123");
-  assert.equal(statSync(keyFile).mode & 0o777, 0o600);
+  // Windows has no POSIX mode bits; the file is protected by the account ACL
+  // (and, since the DPAPI change, the ciphertext itself).
+  if (process.platform !== "win32") {
+    assert.equal(statSync(keyFile).mode & 0o777, 0o600);
+  }
+});
+
+test("key file never stores the plaintext on Windows", () => {
+  const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
+  writeStoredKey(keyFile, "sk-test-123");
+  const raw = readFileSync(keyFile, "utf8");
+  if (process.platform === "win32") {
+    assert.equal(raw.includes("sk-test-123"), false);
+  } else {
+    assert.ok(raw.includes("sk-test-123"));
+  }
+  assert.equal(readStoredKey(keyFile), "sk-test-123");
 });
 
 test("missing or corrupt key files resolve to empty", () => {

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -63,7 +63,7 @@ test("routes V4 Flash to native DeepSeek /responses and preserves SSE", async (t
   }));
   const response = await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json", "content-encoding": "zstd" },
+    headers: { "content-type": "application/json", "content-encoding": "zstd", authorization: "Bearer client-token" },
     body: codexBody,
   });
 
@@ -99,7 +99,7 @@ test("preserves explicit High reasoning", async (t) => {
 
   await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", reasoning: { effort: "high", summary: "auto" } }),
   });
   assert.deepEqual(observed.reasoning, { effort: "high" });
@@ -123,7 +123,7 @@ test("maps stale lower Codex efforts onto DeepSeek High", async (t) => {
 
   await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", reasoning: { effort: "medium" } }),
   });
   assert.deepEqual(observed.reasoning, { effort: "high" });
@@ -182,9 +182,35 @@ test("returns an explicit error when V4 Flash is selected without a key", async 
   t.after(async () => { await close(proxy); });
   const response = await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash" }),
   });
   assert.equal(response.status, 503);
   assert.match((await response.json()).error.message, /DEEPSEEK_API_KEY/);
+});
+
+test("rejects DeepSeek requests without a client authorization header", async (t) => {
+  let upstreamHits = 0;
+  const upstream = http.createServer(async (request, response) => {
+    upstreamHits += 1;
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("{}");
+  });
+  const upstreamUrl = await listen(upstream);
+  const proxy = createProxyServer({
+    deepSeekKey: "test-key",
+    deepSeekBaseUrl: upstreamUrl,
+    logger: { info() {}, error() {} },
+  });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); await close(upstream); });
+
+  const response = await fetch(`${proxyUrl}/v1/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", input: "hello" }),
+  });
+  assert.equal(response.status, 401);
+  assert.equal(upstreamHits, 0);
+  assert.match((await response.json()).error.message, /authorization header/i);
 });

--- a/test/vision.test.mjs
+++ b/test/vision.test.mjs
@@ -206,7 +206,7 @@ test("marks images with a placeholder when the vision call fails", async (t) => 
   assert.ok(collectText(deepSeekReceived[0]).some((text) => text.includes("could not analyze")));
 });
 
-test("skips the vision rewrite without ChatGPT OAuth headers", async (t) => {
+test("rejects DeepSeek-bound image requests without credentials", async (t) => {
   const chatGptCalls = [];
   const deepSeekReceived = [];
   const chatGpt = createFakeChatGpt(chatGptCalls);
@@ -227,7 +227,7 @@ test("skips the vision rewrite without ChatGPT OAuth headers", async (t) => {
     headers: { "content-type": "application/json" },
     body: JSON.stringify(deepSeekRequest([IMAGE_A])),
   });
-  assert.equal(response.status, 200);
+  assert.equal(response.status, 401);
   assert.equal(chatGptCalls.length, 0);
-  assert.equal(countImages(deepSeekReceived[0]), 1);
+  assert.equal(deepSeekReceived.length, 0);
 });


### PR DESCRIPTION
## 背景 / 问题

DSCodex 把 DeepSeek key 视为服务器端配置：任何能访问 `127.0.0.1:10110` 的本地进程都可以直接发送 DeepSeek 模型请求，路由会自动注入 key 并转发，等于匿名消耗用户的 DeepSeek 配额；同时 key 在 `~/.codex/dscodex/config.json` 中以明文保存（Windows 上 0600 权限位不生效，仅依赖账户 ACL）。

## 改动

1. `src/proxy.mjs`：DeepSeek 请求必须携带非空 `Authorization` 头，否则返回 401。Codex 客户端（ChatGPT OAuth 或 API key）总是携带该头，正常使用不受影响；浏览器跨站请求、沙箱进程等匿名调用被拦截。
2. `src/keys.mjs`：Windows 上用 DPAPI（CurrentUser 作用域）加密存储 key（`key_encoding: "dpapi"`），读取时自动解密；旧的明文文件自动兼容。非 Windows 保持原 0600 明文方案。
3. `src/cli.mjs`：`key set` 的提示按平台显示 DPAPI-encrypted 或 mode 0600。
4. 测试：新增“无凭证请求 401”和“Windows 落盘无明文”用例；原“无 OAuth 图片透传”测试改为“无凭证图片请求 401”；Windows 上无效的 POSIX 权限位断言改为平台相关。

## 验证

- `npm test` 34/34 全绿（Windows 实测，包含 DPAPI 真实加密/解密往返）。
- 实测：无凭证请求返回 401；带凭证请求 DeepSeek 正常回复；key 文件内无明文。
- 已知边界：DPAPI 与端口门禁把风险收窄到“同账户恶意代码”这一层；同账户进程仍可读取 `auth.json` 或以用户身份解密，这属于操作系统信任边界，无法由应用层消除。
