### PR TITLE
security: harden router lifecycle, credentials, and proxy handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,13 @@ The non-negotiable details:
 
 1. Never print or commit the DeepSeek API key. Persist it with `node src/cli.mjs key set`
    (`DEEPSEEK_API_KEY` env or the hidden prompt); it is stored at
-   `~/.codex/dscodex/config.json` with mode 0600 and survives logout/reboot. Resolution order at
+   `~/.codex/dscodex/config.json` with mode 0600 (DPAPI-encrypted on Windows) and survives logout/reboot. Resolution order at
    runtime: `DEEPSEEK_API_KEY` env (one-off override), then the stored file, then the legacy macOS
    login-session value. Never store the key in `~/.codex/config.toml`; `uninstall` deletes the
    stored key file.
 2. Run `node src/cli.mjs install`, then `node src/cli.mjs start`, then
-   `node src/cli.mjs doctor`. Doctor must report `ok` for config, catalog, proxy, key, and the
-   app-server bridge. Install must refuse a user-owned `CODEX_CLI_PATH`; it may only install the
+   `node src/cli.mjs doctor`. Doctor must report `ok` for config, catalog, router token, proxy, key,
+   and the app-server bridge. Install must refuse a user-owned `CODEX_CLI_PATH`; it may only install the
    DSCodex wrapper when that login-session variable is absent or already DSCodex-owned. The
    variable must point at the generated shim `~/.codex/dscodex/codex-cli-bridge.sh`, never
    directly at `src/codex-wrapper.mjs`: GUI apps get a bare launchd PATH without Homebrew, so a
@@ -48,7 +48,24 @@ The non-negotiable details:
    macOS, systemd user service `dscodex.service` on Linux, Task Scheduler `DSCodex` plus a hidden
    wscript shim on Windows). The generated plist/unit/VBS must never embed the DeepSeek API key —
    the router resolves it from the stored key file at runtime. KeepAlive/Restart only cover
-   crashes: `stop` sends SIGTERM, the router exits 0 gracefully, and it must stay down. The
+    crashes: `stop` uses the authenticated shutdown endpoint, the router exits 0 gracefully, and it must stay down. The
    `serve` process owns `~/.codex/dscodex/server.pid` no matter who launched it, so `stop` works
    for autostarted instances too. `uninstall` must disable autostart and delete the generated
    artifacts.
+10. The router must reach chatgpt.com for GPT passthrough and GPT vision. Node's fetch ignores
+    proxy environment variables by default, so DSCodex resolves a proxy itself — order:
+    `DSCODEX_HTTPS_PROXY` / `DSCODEX_HTTP_PROXY`, then standard proxy variables (Node gives
+    lowercase names precedence), then the
+    stored `proxy_url` written by `node src/cli.mjs proxy set <url>` in
+    `~/.codex/dscodex/config.json` — and re-execs itself with Node's `--use-env-proxy`
+    (requires Node >= 24.5; uppercase and lowercase proxy variables are synchronized, and
+    `NO_PROXY` always includes loopback plus `api.deepseek.com`). Proxy credentials are redacted
+    in CLI output and DPAPI-protected on Windows; the proxy URL must never be confused with the
+    DeepSeek key, which stays DPAPI/0600-protected and is never printed or committed.
+11. `install` generates a 256-bit router token and writes it into the managed `openai_base_url`;
+    `start` / `serve` must reconcile that marker-owned URL with the persisted token and selected
+    port, and `doctor` must verify the exact binding. The proxy must reject requests without that
+    path token. `serve` owns a 0600 pid-state file with a per-instance shutdown token. `stop` may
+    only use the authenticated shutdown endpoint and must atomically preserve replacement-instance
+    state; it must never terminate an unverified or recycled PID. Cap both compressed request bytes
+    and decompressed request bytes before parsing JSON.

--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@
   <a href="https://api-docs.deepseek.com/zh-cn/guides/responses_api/"><img src="https://img.shields.io/badge/DeepSeek-V4_Flash-4D6BFE?style=flat-square" alt="DeepSeek V4 Flash" /></a>
   <br />
   <a href="https://api-docs.deepseek.com/zh-cn/guides/responses_api/"><img src="https://img.shields.io/badge/Responses_API-native-00A98F?style=flat-square" alt="Native Responses API" /></a>
-  <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%E2%89%A520-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
+  <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%E2%89%A524.5-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js 24.5 or newer" /></a>
   <a href="#requirements"><img src="https://img.shields.io/badge/macOS_%7C_Linux-supported-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS and Linux supported" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-F1C40F?style=flat-square" alt="MIT license" /></a>
 </p>
@@ -53,7 +53,7 @@ IDE extension):
 Codex App / CLI / IDE
         │  HTTP/SSE (zstd-compressed Requests, OAuth headers)
         ▼
-http://127.0.0.1:10110/v1   ← DSCodex loopback router
+http://127.0.0.1:10110/<router-token>/v1   ← authenticated DSCodex loopback router
         │
         ├── model == "deepseek/deepseek-v4-flash"
         │        ▼   (images in the request are described by GPT
@@ -73,7 +73,7 @@ live in that bridge (`~/.codex/dscodex/model-selections.json`).
 
 ## Requirements
 
-- macOS, Linux, or Windows (native, no WSL), Node.js 20+ (Node 26 recommended: built-in zstd)
+- macOS, Linux, or Windows (native, no WSL), Node.js 24.5+ (Node 26 recommended: built-in zstd; proxy mode relies on `--use-env-proxy`)
 - A signed-in ChatGPT desktop app or Codex CLI (for the GPT OAuth models)
 - A DeepSeek API key (`sk-…`)
 - Port `10110` free (change with `--port` or `DSCODEX_PORT`)
@@ -87,10 +87,10 @@ repo and let it read `AGENTS.md`):
 
 1. Get the DeepSeek API key from the user **without printing it or committing it**; store it with
    `DEEPSEEK_API_KEY=sk-… node src/cli.mjs key set` (or the interactive hidden prompt). It lands in
-   `~/.codex/dscodex/config.json` (mode 0600) and survives logout/reboot.
+   `~/.codex/dscodex/config.json` (mode 0600; DPAPI-encrypted on Windows) and survives logout/reboot.
 2. `node src/cli.mjs install` — writes two marker-owned root keys and merges `🐳 V4 Flash` into
    the catalog; refuses to overwrite a user-owned `openai_base_url`.
-3. `node src/cli.mjs start`, then `node src/cli.mjs doctor` — all five checks, including the
+3. `node src/cli.mjs start`, then `node src/cli.mjs doctor` — all six checks, including the
    app-server bridge, must be `ok`.
 4. `npm test` — all tests pass.
 5. Have the user fully quit (`⌘Q`) and relaunch the ChatGPT app, start a **new** task, and pick
@@ -105,6 +105,7 @@ repo and let it read `AGENTS.md`):
 ```bash
 cd /path/to/DSCodex
 node src/cli.mjs key set   # hidden prompt; stored in ~/.codex/dscodex/config.json (0600)
+node src/cli.mjs proxy set http://127.0.0.1:10808   # optional: needed when chatgpt.com requires a proxy
 node src/cli.mjs install
 node src/cli.mjs start
 node src/cli.mjs doctor
@@ -116,7 +117,7 @@ Then quit and relaunch the ChatGPT desktop app, start a new task, and choose `�
 On Windows (PowerShell) the commands are identical; to pass the key via environment use
 `$env:DEEPSEEK_API_KEY="sk-…"; node src/cli.mjs key set`.
 
-Commands: `install`, `sync`, `key set|status|delete`, `start`, `serve`,
+Commands: `install`, `sync`, `key set|status|delete`, `proxy set|status|clear`, `start`, `serve`,
 `autostart enable|disable|status`, `status`, `doctor`, `stop`, `uninstall`.
 
 CLI note: `-m deepseek/deepseek-v4-flash` without the override may show `High`; add
@@ -151,16 +152,33 @@ CLI note: `-m deepseek/deepseek-v4-flash` without the override may show `High`; 
   placeholder is injected so DeepSeek can honestly say it cannot see the image. Descriptions are
   cached in router memory only; if the app-server re-encodes an image the data URL changes and the
   image is described again.
+- **Proxy.** The router must reach chatgpt.com itself: Node's fetch ignores system/proxy
+  environment variables by default, so DSCodex resolves a proxy on its own
+  (`DSCODEX_HTTPS_PROXY` / `DSCODEX_HTTP_PROXY` → lowercase/uppercase standard proxy variables
+  with Node's lowercase precedence → the value stored by `proxy set`) and re-execs itself with `--use-env-proxy` (Node
+  >= 24.5). GPT passthrough and GPT vision share the same path. `NO_PROXY` always includes
+  loopback addresses and `api.deepseek.com`, so DeepSeek remains direct; both uppercase and
+  lowercase proxy variables are set consistently for child processes. Proxy URLs may contain
+  credentials; they are redacted in CLI output and encrypted with DPAPI on Windows.
 - **WebSocket warning.** The catalog declares `prefer_websockets = false`; the router answers
   probes with `426`, and Codex falls back to HTTP/SSE. `codex doctor` may still show a warning;
   requests succeed.
 - **Voice, pets, plugins, skills, MCP.** All client-side; voice is driven by GPT-Live and never
   routes to DeepSeek.
-- **API key storage.** The key is stored in plaintext at `~/.codex/dscodex/config.json` (mode 0600,
-  directory 0700); it survives logout/reboot and is protected only by file permissions. If plaintext
-  at rest is unacceptable, skip `key set` and export `DEEPSEEK_API_KEY` per session instead (or
-  `launchctl setenv` on macOS). Resolution order at runtime: environment variable, then the stored
-  file, then the macOS login session; `key delete` plus a router restart removes it completely.
+- **API key storage.** The key is stored in `~/.codex/dscodex/config.json` (mode 0600, directory 0700);
+  Windows uses per-user DPAPI encryption and POSIX systems use the owner-only file. It survives
+  logout/reboot; legacy Windows plaintext keys migrate on the next install, start, or state write.
+  If persistent storage is unacceptable, skip `key set` and export
+  `DEEPSEEK_API_KEY` per session instead (or `launchctl setenv` on macOS). Resolution order at
+  runtime: environment variable, then the stored file, then the macOS login session; `key delete`
+  plus a router restart removes it completely.
+- **Loopback boundary.** `install` generates a 256-bit router token and adds it to
+  `openai_base_url`; `start` / `serve` reconcile the managed URL, port, and token, and `doctor`
+  verifies the exact binding. Requests without the token receive 404. The token is also required
+  for the authenticated shutdown handshake, and PID cleanup atomically claims the matching
+  instance state, so `stop` neither removes a replacement instance's state nor signals an
+  unverified PID. Request and decompressed-body limits protect the local process from accidental
+  or hostile memory spikes.
 - **Platform differences.** Routing, key storage, and catalog merging behave identically on every
   platform; the app-server bridge (picker-state memory for the desktop app) is macOS-only. Windows
   desktop apps spawn `CODEX_CLI_PATH` directly and CreateProcess cannot run a script shim (only an

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://api-docs.deepseek.com/zh-cn/guides/responses_api/"><img src="https://img.shields.io/badge/DeepSeek-V4_Flash-4D6BFE?style=flat-square" alt="DeepSeek V4 Flash" /></a>
   <br />
   <a href="https://api-docs.deepseek.com/zh-cn/guides/responses_api/"><img src="https://img.shields.io/badge/Responses_API-native-00A98F?style=flat-square" alt="Native Responses API" /></a>
-  <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%E2%89%A520-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js 20 or newer" /></a>
+  <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%E2%89%A524.5-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js 24.5 or newer" /></a>
   <a href="#环境要求"><img src="https://img.shields.io/badge/macOS_%7C_Linux-supported-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS and Linux supported" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-F1C40F?style=flat-square" alt="MIT license" /></a>
 </p>
@@ -41,7 +41,7 @@ DSCodex 是一个约 40 KB、零依赖的 Node 本地路由，把 DeepSeek V4 Fl
 Codex App / CLI / IDE
         │  HTTP/SSE（zstd 压缩请求、OAuth 头）
         ▼
-http://127.0.0.1:10110/v1   ← DSCodex 本地路由
+http://127.0.0.1:10110/<router-token>/v1   ← 带认证的 DSCodex 本地路由
         │
         ├── model == "deepseek/deepseek-v4-flash"
         │        ▼   （请求里的图片先经 chatgpt.com 做 GPT 识图，
@@ -57,7 +57,7 @@ http://127.0.0.1:10110/v1   ← DSCodex 本地路由
 
 ## 环境要求
 
-- macOS、Linux 或 Windows（原生，无需 WSL），Node.js 20+（推荐 26，自带 zstd）
+- macOS、Linux 或 Windows（原生，无需 WSL），Node.js 24.5+（推荐 26，自带 zstd；代理模式依赖 24.5+ 的 `--use-env-proxy`）
 - 已登录的 ChatGPT 桌面端或 Codex CLI（GPT OAuth 模型需要）
 - DeepSeek API Key（`sk-…`）
 - 端口 `10110` 空闲（`--port` 或 `DSCODEX_PORT` 可改）
@@ -68,9 +68,9 @@ http://127.0.0.1:10110/v1   ← DSCodex 本地路由
 
 仓库按“克隆下来直接让 Agent 装”设计。把本 README 交给 Agent（或克隆仓库让它读 `AGENTS.md`）：
 
-1. 拿到 DeepSeek API Key，**不要打印、不要提交进仓库**；存入本地配置：`DEEPSEEK_API_KEY=sk-… node src/cli.mjs key set`（或交互隐藏输入），落在 `~/.codex/dscodex/config.json`（权限 0600），重启/注销后仍有效。
+1. 拿到 DeepSeek API Key，**不要打印、不要提交进仓库**；存入本地配置：`DEEPSEEK_API_KEY=sk-… node src/cli.mjs key set`（或交互隐藏输入），落在 `~/.codex/dscodex/config.json`（权限 0600；Windows 使用 DPAPI 加密），重启/注销后仍有效。
 2. `node src/cli.mjs install` —— 写入两条带标记的根配置，把 `🐳 V4 Flash` 合入模型目录；遇到用户自有的 `openai_base_url` 拒绝覆盖。
-3. `node src/cli.mjs start`，再 `node src/cli.mjs doctor` —— 五项检查（含 app-server bridge）必须全部 `ok`。
+3. `node src/cli.mjs start`，再 `node src/cli.mjs doctor` —— 六项检查（含路由令牌和 app-server bridge）必须全部 `ok`。
 4. `npm test` —— 全部测试通过。
 5. 让用户完全退出（`⌘Q`）并重开 ChatGPT 桌面端，新建任务后选择 `🐳 V4 Flash`。
 6. 验证真实工具循环：`codex -m deepseek/deepseek-v4-flash -c 'model_reasoning_effort="max"' -a never exec --skip-git-repo-check 'call a shell tool once …'` —— 模型必须发起工具调用、读取输出并正常结束。
@@ -80,6 +80,7 @@ http://127.0.0.1:10110/v1   ← DSCodex 本地路由
 ```bash
 cd /path/to/DSCodex
 node src/cli.mjs key set   # 隐藏输入,存入 ~/.codex/dscodex/config.json (0600)
+node src/cli.mjs proxy set http://127.0.0.1:10808   # 可选:chatgpt.com 需要代理时（如大陆网络）
 node src/cli.mjs install
 node src/cli.mjs start
 node src/cli.mjs doctor
@@ -90,7 +91,7 @@ node src/cli.mjs autostart enable   # 可选:登录自启路由 (launchd / syste
 
 Windows（PowerShell）命令相同；用环境变量方式存 key 时写成 `$env:DEEPSEEK_API_KEY="sk-…"; node src/cli.mjs key set`。
 
-命令：`install`、`sync`、`key set|status|delete`、`start`、`serve`、`autostart enable|disable|status`、`status`、`doctor`、`stop`、`uninstall`。
+命令：`install`、`sync`、`key set|status|delete`、`proxy set|status|clear`、`start`、`serve`、`autostart enable|disable|status`、`status`、`doctor`、`stop`、`uninstall`。
 
 CLI 注意：`-m deepseek/deepseek-v4-flash` 不带覆盖参数时可能显示 `High`；需要 Max 时加 `-c 'model_reasoning_effort="max"'`。
 
@@ -114,9 +115,11 @@ CLI 注意：`-m deepseek/deepseek-v4-flash` 不带覆盖参数时可能显示 `
 
 - **用量统计。** Codex App「Profile」的用量统计是只读的，无法计入 DeepSeek 用量——已实测。
 - **GPT 识图。** 识图借用请求自带的 ChatGPT OAuth 头，描述质量取决于 GPT 模型（默认 `gpt-5.6-sol`，`DSCODEX_VISION_MODEL` 可换）。无 OAuth 头（纯 API key 场景）时图片原样透传；识图失败时注入明确占位文本，DeepSeek 会如实说看不到。描述缓存在路由进程内存中，重启失效；app-server 若重新编码图片，data URL 变化会导致重新描述。
+- **代理。** 路由器必须能访问 chatgpt.com：Node 的 fetch 默认忽略系统/环境代理，因此 DSCodex 会自行解析代理（`DSCODEX_HTTPS_PROXY` / `DSCODEX_HTTP_PROXY` → 按 Node 规则优先小写的标准代理变量 → `proxy set` 存储值），并以 `--use-env-proxy` 重启自身（Node ≥24.5）。GPT 转发与 GPT 识图同链路生效；`NO_PROXY` 默认含回环地址和 `api.deepseek.com`，DeepSeek 保持直连。大小写代理变量会同步设置，带用户名/密码的代理 URL 会在 CLI 输出中脱敏，Windows 上用 DPAPI 加密保存。
 - **WebSocket 警告。** 目录声明 `prefer_websockets = false`，路由对探测回 `426`，Codex 回退 HTTP/SSE；`codex doctor` 可能仍显示警告，但请求正常。
 - **Voice、Pets、插件、技能、MCP。** 都是客户端功能；语音由 GPT-Live 驱动，不会路由到 DeepSeek。
-- **Key 存储。** 明文保存在 `~/.codex/dscodex/config.json`（权限 0600，目录 0700），重启/注销后仍然有效，仅靠文件权限保护——介意明文落盘的话不要 `key set`，退回每次会话 export `DEEPSEEK_API_KEY`（或 macOS `launchctl setenv`）。运行时取值顺序：环境变量 → 存储文件 → macOS 登录会话；`key delete` 并重启路由即彻底清除。
+- **Key 存储。** 保存在 `~/.codex/dscodex/config.json`（权限 0600，目录 0700）；Windows 使用当前用户 DPAPI 加密，POSIX 系统依靠仅所有者可读的文件权限。旧版 Windows 明文 key 会在下一次安装、启动或配置写入时自动迁移。介意持久化的话不要 `key set`，改用每次会话的 `DEEPSEEK_API_KEY`（或 macOS `launchctl setenv`）。运行时取值顺序：环境变量 → 存储文件 → macOS 登录会话；`key delete` 并重启路由即彻底清除。
+- **本地边界。** `install` 会生成 256 位路由令牌并写入 `openai_base_url`；`start` / `serve` 会校准 CLI 自有的 URL、端口和令牌，`doctor` 会验证三者一致，不带令牌的请求返回 404。`stop` 使用同一令牌和一次性关闭令牌握手，并以实例身份原子认领 PID 状态，不会删除替代实例的状态或向未经验证的 PID 发信号；请求体和解压后请求体均有限制，避免本地进程因异常输入发生内存峰值。
 - **平台差异。** 路由、key 存储、目录合并全平台一致；app-server bridge（桌面端模型菜单的状态记忆）仅 macOS——Windows 桌面端直接 spawn `CODEX_CLI_PATH`，脚本 shim 起不来（CreateProcess 只认 `.exe`），因此 Windows 上 `install` 跳过 bridge、`doctor` 对应项自动 `ok`。Windows 的配置目录同样是 `%USERPROFILE%\.codex`；key 文件的 0600 权限位在 Windows 不生效，依赖账户 ACL 保护。路由默认不随机启动；`node src/cli.mjs autostart enable` 可注册登录自启（macOS launchd / Linux systemd user service / Windows 任务计划），崩溃会被自动拉起，而手动 `stop` 是优雅退出（退出码 0），不会被复活；`autostart disable` 和 `uninstall` 都会移除自启项。未开启自启时，重启后重新 `node src/cli.mjs start` 即可（key 已持久化，无需重配）。
 
 ## 任务中思考为什么反复折叠

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "doctor": "node ./src/cli.mjs doctor"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24.5"
   },
   "license": "MIT"
 }

--- a/src/autostart.mjs
+++ b/src/autostart.mjs
@@ -82,19 +82,42 @@ WantedBy=default.target
 `;
 }
 
-// The task runs wscript.exe on this one-liner so no console window flashes at
-// logon; cmd routes stdout/stderr into the regular server.log.
-export function buildWindowsVbs({ nodePath, cliPath, port, logPath, homeDir = homedir() }) {
-  // wscript reads .vbs files as ANSI (GBK on zh-CN systems), so a literal log
-  // path containing a non-ASCII user name becomes mojibake and cmd cannot open
-  // it. Redirect through %USERPROFILE% (expanded by cmd at runtime) instead.
-  let log = logPath;
-  const homePrefix = homeDir.replace(/[\\/]+$/, "");
-  const lowerLog = logPath.toLowerCase();
+function psQuote(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function winQuote(value) {
+  return `"${String(value).replaceAll('"', '\\"')}"`;
+}
+
+function powershellPath() {
+  return join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+function psPath(value, homeDir) {
+  const path = String(value);
+  const homePrefix = String(homeDir).replace(/[\\/]+$/, "");
+  const lowerPath = path.toLowerCase();
   const lowerHome = homePrefix.toLowerCase();
-  if (lowerLog.startsWith(`${lowerHome}\\`) || lowerLog.startsWith(`${lowerHome}/`)) {
-    log = `%USERPROFILE%${logPath.slice(homePrefix.length)}`;
+  if (homePrefix && lowerPath === lowerHome) return "$env:USERPROFILE";
+  if (homePrefix && (lowerPath.startsWith(`${lowerHome}\\`) || lowerPath.startsWith(`${lowerHome}/`))) {
+    // wscript reads generated .vbs files through the active ANSI code page.
+    // Keep non-ASCII user names out of the VBS source and resolve them at run time.
+    return `($env:USERPROFILE + ${psQuote(path.slice(homePrefix.length))})`;
   }
-  const cmd = `cmd /c ""${nodePath}" "${cliPath}" serve --port ${port} >> "${log}" 2>&1"`;
-  return `CreateObject("Wscript.Shell").Run "${cmd.replaceAll('"', '""')}", 0, False\r\n`;
+  return psQuote(path);
+}
+
+// The task runs wscript.exe on this one-liner so no console window flashes at
+// logon. It deliberately avoids `cmd /c`: a cmd string would need escaping for
+// `&`, `^`, `|`, `<`, `>` etc., so paths (which may contain those characters)
+// are passed to PowerShell as single-quoted arguments instead and the router
+// log is appended with PowerShell's `*>>`.
+export function buildWindowsVbs({ nodePath, cliPath, port, logPath, homeDir = homedir() }) {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${port}`);
+  }
+  const script = `$ErrorActionPreference='Stop'; & ${psPath(nodePath, homeDir)} ${psPath(cliPath, homeDir)} serve --port ${port} *>> ${psPath(logPath, homeDir)}`;
+  const commandLine = `${winQuote(powershellPath())} -NoProfile -NonInteractive -WindowStyle Hidden -Command ${winQuote(script)}`;
+  return `CreateObject("Wscript.Shell").Run "${commandLine.replaceAll('"', '""')}", 0, False\r\n`;
 }

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -78,11 +78,14 @@ export function buildCatalog(cache) {
   };
 }
 
-export function syncCatalog({ cachePath, catalogPath }) {
-  const cache = JSON.parse(readFileSync(cachePath, "utf8"));
-  const catalog = buildCatalog(cache);
+export function writeCatalog({ catalogPath, catalog }) {
   const temporary = `${catalogPath}.dscodex-tmp-${process.pid}`;
   writeFileSync(temporary, `${JSON.stringify(catalog, null, 2)}\n`, { mode: 0o600 });
   renameSync(temporary, catalogPath);
   return catalog;
+}
+
+export function syncCatalog({ cachePath, catalogPath }) {
+  const cache = JSON.parse(readFileSync(cachePath, "utf8"));
+  return writeCatalog({ catalogPath, catalog: buildCatalog(cache) });
 }

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -420,7 +420,7 @@ async function manageKey(subcommand, paths, port) {
   if (subcommand === "set") {
     const key = process.env.DEEPSEEK_API_KEY?.trim() || launchctlKey() || await promptSecret("DeepSeek API Key: ");
     writeStoredKey(paths.keyFile, key);
-    console.log(`Stored DeepSeek API key in ${paths.keyFile} (mode 0600)`);
+    console.log(`Stored DeepSeek API key in ${paths.keyFile} (${process.platform === "win32" ? "DPAPI-encrypted" : "mode 0600"})`);
     if (await health(port)) console.log("Restart the router (stop && start) so the running server picks up the new key");
     return;
   }

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -364,8 +364,22 @@ async function serve(port) {
       stdio: "inherit",
       windowsHide: true,
     });
+    const forwardedSignals = new Map();
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      const handler = () => child.kill(signal);
+      forwardedSignals.set(signal, handler);
+      process.once(signal, handler);
+    }
+    child.once("error", (error) => {
+      console.error(`${ts()} dscodex: failed to start proxy re-exec: ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+    });
     child.once("exit", (code, signal) => {
-      if (signal) process.kill(process.pid, signal);
+      if (signal) {
+        const handler = forwardedSignals.get(signal);
+        if (handler) process.removeListener(signal, handler);
+        process.kill(process.pid, signal);
+      }
       else process.exit(code ?? 1);
     });
     return;

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -2,19 +2,43 @@
 import {
   closeSync,
   existsSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { request as httpRequest } from "node:http";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { buildCatalog, syncCatalog } from "./catalog.mjs";
-import { install, uninstall } from "./config.mjs";
-import { deleteStoredKey, readStoredKey, writeStoredKey } from "./keys.mjs";
+import {
+  ensureManagedRouterBinding,
+  install,
+  managedRouterConfigMatches,
+  uninstall,
+} from "./config.mjs";
+import {
+  deleteStoredKey,
+  readProxyUrl,
+  readRouterToken,
+  readStoredKey,
+  writeProxyUrl,
+  writeStoredKey,
+} from "./keys.mjs";
+import {
+  envProxySupported,
+  proxyEnvFor,
+  proxySource,
+  resolveProxy,
+  redactProxyUrl,
+  validateProxyUrl,
+} from "./proxy-config.mjs";
 import { createProxyServer } from "./proxy.mjs";
 import {
   LAUNCHD_LABEL,
@@ -30,6 +54,10 @@ import {
 import { DEFAULT_PORT, HOST, VERSION, pathsFor, resolveCodexHome } from "./constants.mjs";
 
 const APP_SERVER_WRAPPER = fileURLToPath(new URL("./codex-wrapper.mjs", import.meta.url));
+
+function ts() {
+  return new Date().toISOString();
+}
 
 function launchctlGet(name) {
   if (process.platform !== "darwin") return process.env[name]?.trim() ?? "";
@@ -170,10 +198,60 @@ function promptSecret(prompt) {
   });
 }
 
-async function health(port) {
+const MAX_CONTROL_RESPONSE_BYTES = 64 * 1024;
+
+function loopbackRequest({ port, path, method = "GET", headers = {}, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      callback(value);
+    };
+    const request = httpRequest({
+      hostname: HOST,
+      port,
+      path,
+      method,
+      headers,
+      // Never inherit a patched/global agent: control-plane credentials must
+      // stay on loopback even when Node's global fetch uses an env proxy.
+      agent: false,
+    }, (response) => {
+      const chunks = [];
+      let total = 0;
+      response.on("data", (chunk) => {
+        total += chunk.length;
+        if (total > MAX_CONTROL_RESPONSE_BYTES) {
+          const error = new Error("DSCodex loopback response exceeds the configured limit");
+          settle(reject, error);
+          response.destroy();
+          request.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.once("end", () => {
+        settle(resolve, {
+          statusCode: response.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+      });
+      response.once("error", (error) => settle(reject, error));
+    });
+    request.once("error", (error) => settle(reject, error));
+    request.setTimeout(timeoutMs, () => request.destroy(new Error("DSCodex loopback request timed out")));
+    request.end();
+  });
+}
+
+async function health(port, routerToken = "") {
   try {
-    const response = await fetch(`http://${HOST}:${port}/health`, { signal: AbortSignal.timeout(700) });
-    return response.ok ? await response.json() : null;
+    const path = routerToken ? `/${routerToken}/health` : "/health";
+    const response = await loopbackRequest({ port, path, timeoutMs: 700 });
+    return response.statusCode >= 200 && response.statusCode < 300
+      ? JSON.parse(response.body)
+      : null;
   } catch {
     return null;
   }
@@ -191,72 +269,220 @@ function loadModels(paths) {
   return [];
 }
 
+function tokenValue(value) {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+function writePidState(paths, state) {
+  const temporary = `${paths.pid}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+  renameSync(temporary, paths.pid);
+}
+
+function readPidState(paths) {
+  if (!existsSync(paths.pid)) return null;
+  let state;
+  try {
+    state = JSON.parse(readFileSync(paths.pid, "utf8"));
+  } catch {
+    throw new Error(`Invalid DSCodex pid state at ${paths.pid}; remove it after verifying no router is running`);
+  }
+  if (!Number.isInteger(state?.pid) || state.pid < 1
+    || !Number.isInteger(state.port) || state.port < 1 || state.port > 65535
+    || !tokenValue(state.routerToken) || !tokenValue(state.shutdownToken)
+    || typeof state.instanceId !== "string"
+    || !new RegExp(`^${state.pid}-\\d+-[0-9a-f]{16}$`).test(state.instanceId)) {
+    throw new Error(`Untrusted DSCodex pid state at ${paths.pid}; refusing to stop an unverified process`);
+  }
+  return state;
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function removePidState(paths, expected) {
+  if (!Number.isInteger(expected?.pid) || typeof expected.instanceId !== "string") {
+    throw new Error("Refusing to remove DSCodex pid state without an instance identity");
+  }
+  if (!existsSync(paths.pid)) return;
+  const claimed = `${paths.pid}.remove-${process.pid}-${randomBytes(8).toString("hex")}`;
+  try {
+    // Claim the current pathname atomically. A replacement instance can publish
+    // a new server.pid immediately afterwards without it being unlinked here.
+    renameSync(paths.pid, claimed);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  let matches = false;
+  try {
+    const current = JSON.parse(readFileSync(claimed, "utf8"));
+    matches = current?.pid === expected.pid && current?.instanceId === expected.instanceId;
+  } catch {
+    // An invalid or replacement state must be restored, not discarded.
+  }
+  if (matches) {
+    unlinkSync(claimed);
+    return;
+  }
+  try {
+    // linkSync is create-if-absent: it cannot overwrite a still newer pid file.
+    linkSync(claimed, paths.pid);
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  unlinkSync(claimed);
+}
+
 async function serve(port) {
-  process.title = "dscodex";
   const { paths } = runtime();
+  const binding = ensureManagedRouterBinding({ paths, port });
+  const routerToken = binding.routerToken;
+  if (binding.updated) console.log(`${ts()} Updated the managed router URL for the active token and port`);
+  const storedProxy = readProxyUrl(paths.keyFile);
+  const proxyUrl = resolveProxy(process.env, storedProxy);
+  if (proxyUrl && !envProxySupported()) {
+    console.error(`${ts()} dscodex: proxy support requires Node.js >= 24.5 (found ${process.version}); ` +
+      "upgrade Node or clear the proxy (proxy clear)");
+    process.exitCode = 1;
+    return;
+  }
+  // Node's fetch ignores proxy env vars unless --use-env-proxy is active.
+  // Re-exec ourselves with the flag (and the resolved proxy in the env) so
+  // `start`, autostart, and a manual `serve` all behave identically.
+  if (proxyUrl && process.env.DSCODEX_PROXY_REEXEC !== "1") {
+    const child = spawn(process.execPath, [fileURLToPath(import.meta.url), ...process.argv.slice(2)], {
+      env: { ...process.env, ...proxyEnvFor(proxyUrl, process.env), DSCODEX_PROXY_REEXEC: "1" },
+      stdio: "inherit",
+      windowsHide: true,
+    });
+    child.once("exit", (code, signal) => {
+      if (signal) process.kill(process.pid, signal);
+      else process.exit(code ?? 1);
+    });
+    return;
+  }
   syncIfPossible(paths);
   const deepSeekKey = resolveDeepSeekKey(process.env, paths.keyFile);
-  const server = createProxyServer({ deepSeekKey, models: loadModels(paths) });
+  const logger = {
+    info: (message) => console.log(`${ts()} ${message}`),
+    error: (message) => console.error(`${ts()} ${message}`),
+  };
+  const shutdownToken = randomBytes(32).toString("base64url");
+  const instanceId = `${process.pid}-${Date.now()}-${randomBytes(8).toString("hex")}`;
+  let server;
+  let shuttingDown = false;
+  const shutdown = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    const forceTimer = setTimeout(() => server.closeAllConnections?.(), 5_000);
+    server.close(() => {
+      clearTimeout(forceTimer);
+      removePidState(paths, { pid: process.pid, instanceId });
+      process.exit(0);
+    });
+  };
+  server = createProxyServer({
+    deepSeekKey,
+    models: loadModels(paths),
+    logger,
+    routerToken,
+    shutdownToken,
+    instanceId,
+    onShutdown: shutdown,
+  });
   // The serve process owns the pid file so `stop` works no matter who launched
   // it — `start`, launchd, systemd, or the Windows Task Scheduler.
   mkdirSync(paths.stateDir, { recursive: true, mode: 0o700 });
-  writeFileSync(paths.pid, `${JSON.stringify({ pid: process.pid, port })}\n`, { mode: 0o600 });
-  const shutdown = () => server.close(() => {
-    try {
-      unlinkSync(paths.pid);
-    } catch {
-      // Already removed by `stop`.
-    }
-    process.exit(0);
-  });
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
+  server.once("error", (error) => {
+    console.error(`${ts()} dscodex: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
   server.listen(port, HOST, () => {
-    console.log(`DSCodex ${VERSION} listening at http://${HOST}:${port}/v1`);
-    console.log(`DeepSeek key: ${deepSeekKey ? "configured" : "missing (GPT OAuth passthrough still works)"}`);
+    writePidState(paths, { pid: process.pid, port, routerToken, shutdownToken, instanceId });
+    console.log(`${ts()} DSCodex ${VERSION} listening at http://${HOST}:${port}/v1`);
+    console.log(`${ts()} DeepSeek key: ${deepSeekKey ? "configured" : "missing (GPT OAuth passthrough still works)"}`);
   });
 }
 
-function stopInstance(paths) {
-  if (!existsSync(paths.pid)) return "none";
-  const state = JSON.parse(readFileSync(paths.pid, "utf8"));
-  try {
-    process.kill(state.pid, "SIGTERM");
-  } catch (error) {
-    if (error?.code !== "ESRCH") throw error;
-    if (existsSync(paths.pid)) unlinkSync(paths.pid);
+async function stopInstance(paths) {
+  const state = readPidState(paths);
+  if (!state) return "none";
+  const expected = { pid: state.pid, instanceId: state.instanceId };
+  if (!processAlive(state.pid)) {
+    removePidState(paths, expected);
     return "stale";
   }
-  // The graceful shutdown (exit 0) is exactly what launchd KeepAlive
-  // (SuccessfulExit=false) and systemd Restart=on-failure leave alone.
-  if (existsSync(paths.pid)) unlinkSync(paths.pid);
-  return "stopped";
+  try {
+    const response = await loopbackRequest({
+      port: state.port,
+      path: `/${state.routerToken}/_dscodex/shutdown`,
+      method: "POST",
+      headers: { "x-dscodex-shutdown-token": state.shutdownToken },
+      timeoutMs: 1_500,
+    });
+    if (response.statusCode !== 202) {
+      throw new Error(`router rejected the authenticated shutdown request (${response.statusCode})`);
+    }
+  } catch (error) {
+    if (!processAlive(state.pid)) {
+      removePidState(paths, expected);
+      return "stale";
+    }
+    throw new Error(`Could not authenticate shutdown for PID ${state.pid}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (!processAlive(state.pid) || !existsSync(paths.pid)) {
+      removePidState(paths, expected);
+      return "stopped";
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Router PID ${state.pid} did not exit after authenticated shutdown`);
 }
 
 async function start(port) {
-  const running = await health(port);
+  const { paths } = runtime();
+  const binding = ensureManagedRouterBinding({ paths, port });
+  const routerToken = binding.routerToken;
+  if (binding.updated) console.log("Updated the managed router URL for the active token and port");
+  const running = await health(port, routerToken);
   if (running) {
     console.log(`DSCodex is already running on ${HOST}:${port}`);
     return;
   }
-  const { paths } = runtime();
   mkdirSync(paths.stateDir, { recursive: true, mode: 0o700 });
   syncIfPossible(paths);
-  const deepSeekKey = resolveDeepSeekKey(process.env, paths.keyFile);
   const logFd = openSync(paths.log, "a", 0o600);
   const child = spawn(process.execPath, [fileURLToPath(import.meta.url), "serve", "--port", String(port)], {
     detached: true,
     windowsHide: true,
-    env: { ...process.env, ...(deepSeekKey ? { DEEPSEEK_API_KEY: deepSeekKey } : {}) },
+    env: { ...process.env },
     stdio: ["ignore", logFd, logFd],
   });
   child.unref();
   closeSync(logFd);
   for (let attempt = 0; attempt < 30; attempt += 1) {
     await new Promise((resolve) => setTimeout(resolve, 100));
-    const ready = await health(port);
+    const ready = await health(port, routerToken);
     if (ready) {
-      console.log(`DSCodex started on ${HOST}:${port} (pid ${child.pid})`);
+      let pid = child.pid;
+      try {
+        pid = JSON.parse(readFileSync(paths.pid, "utf8")).pid ?? pid;
+      } catch {
+        // The pid file appears slightly after readiness; keep the child pid.
+      }
+      console.log(`DSCodex started on ${HOST}:${port} (pid ${pid})`);
       console.log(`DeepSeek key: ${ready.deepseek_key ? "configured" : "missing"}`);
       return;
     }
@@ -266,10 +492,10 @@ async function start(port) {
 
 async function stop() {
   const { paths } = runtime();
-  const result = stopInstance(paths);
-  if (result === "none") console.log("DSCodex is not running (no pid file)");
-  else if (result === "stale") console.log("Removed stale DSCodex pid file");
-  else console.log("Stopped DSCodex");
+  const result = await stopInstance(paths);
+  if (result === "none") console.log(`${ts()} DSCodex is not running (no pid file)`);
+  else if (result === "stale") console.log(`${ts()} Removed stale DSCodex pid file`);
+  else console.log(`${ts()} Stopped DSCodex`);
 }
 
 function autostartFile(paths) {
@@ -297,12 +523,15 @@ async function autostartEnable(paths, port) {
   const kind = autostartKind();
   const file = autostartFile(paths);
   const cliPath = fileURLToPath(import.meta.url);
+  const binding = ensureManagedRouterBinding({ paths, port });
+  const routerToken = binding.routerToken;
+  if (binding.updated) console.log("Updated the managed router URL for the active token and port");
   mkdirSync(paths.stateDir, { recursive: true, mode: 0o700 });
 
   // Free the port so the manager-launched instance can bind immediately.
-  if (await health(port)) {
-    stopInstance(paths);
-    for (let attempt = 0; attempt < 30 && (await health(port)); attempt += 1) {
+  if (await health(port, routerToken)) {
+    await stopInstance(paths);
+    for (let attempt = 0; attempt < 30 && (await health(port, routerToken)); attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
@@ -336,7 +565,7 @@ async function autostartEnable(paths, port) {
 
   for (let attempt = 0; attempt < 50; attempt += 1) {
     await new Promise((resolve) => setTimeout(resolve, 100));
-    const ready = await health(port);
+    const ready = await health(port, routerToken);
     if (ready) {
       console.log(`DSCodex autostart enabled (${kind}); router running on ${HOST}:${port}`);
       console.log(`DeepSeek key: ${ready.deepseek_key ? "configured" : "missing (resolves from the stored key at runtime)"}`);
@@ -393,7 +622,7 @@ function autostartDisable(paths, { quiet = false } = {}) {
 async function autostartStatus(paths, port) {
   const kind = autostartKind();
   const enabled = autostartEnabled(paths);
-  const ready = await health(port);
+  const ready = await health(port, readRouterToken(paths.keyFile));
   console.log(`autostart: ${enabled ? `enabled (${kind}, port in config: see ${autostartFile(paths)})` : "not enabled"}`);
   console.log(`router: ${ready ? `running (${HOST}:${port})` : "stopped"}`);
   if (!enabled) process.exitCode = 1;
@@ -407,7 +636,8 @@ async function manageAutostart(subcommand, paths, port) {
 }
 
 async function status(port) {
-  const ready = await health(port);
+  const { paths } = runtime();
+  const ready = await health(port, readRouterToken(paths.keyFile));
   if (!ready) {
     console.log(`stopped (${HOST}:${port})`);
     process.exitCode = 1;
@@ -421,13 +651,13 @@ async function manageKey(subcommand, paths, port) {
     const key = process.env.DEEPSEEK_API_KEY?.trim() || launchctlKey() || await promptSecret("DeepSeek API Key: ");
     writeStoredKey(paths.keyFile, key);
     console.log(`Stored DeepSeek API key in ${paths.keyFile} (${process.platform === "win32" ? "DPAPI-encrypted" : "mode 0600"})`);
-    if (await health(port)) console.log("Restart the router (stop && start) so the running server picks up the new key");
+    if (await health(port, readRouterToken(paths.keyFile))) console.log("Restart the router (stop && start) so the running server picks up the new key");
     return;
   }
   if (subcommand === "delete") {
     deleteStoredKey(paths.keyFile);
-    console.log(`Removed ${paths.keyFile}`);
-    if (await health(port)) console.log("Restart the router (stop && start) to drop the in-memory key");
+    console.log(`Removed the stored DeepSeek API key from ${paths.keyFile}`);
+    if (await health(port, readRouterToken(paths.keyFile))) console.log("Restart the router (stop && start) to drop the in-memory key");
     return;
   }
   if (subcommand === "status") {
@@ -438,13 +668,44 @@ async function manageKey(subcommand, paths, port) {
   throw new Error(`Unknown key subcommand: ${subcommand}`);
 }
 
+async function manageProxy(subcommand, args, paths, port) {
+  if (subcommand === "set") {
+    const url = (args[0] ?? "").trim() || process.env.DSCODEX_PROXY?.trim();
+    if (!url) throw new Error("Usage: dscodex proxy set http://127.0.0.1:10808 (or set DSCODEX_PROXY)");
+    const validated = validateProxyUrl(url);
+    writeProxyUrl(paths.keyFile, validated);
+    console.log(`Stored proxy ${redactProxyUrl(validated)} in ${paths.keyFile}`);
+    if (await health(port, readRouterToken(paths.keyFile))) console.log("Restart the router (stop && start) so the running server picks it up");
+    return;
+  }
+  if (subcommand === "status") {
+    const stored = readProxyUrl(paths.keyFile);
+    const resolved = resolveProxy(process.env, stored);
+    console.log(resolved ? `proxy: configured (${proxySource(process.env, stored)})` : "proxy: missing");
+    return;
+  }
+  if (subcommand === "clear") {
+    writeProxyUrl(paths.keyFile, "");
+    console.log(`Removed proxy from ${paths.keyFile}`);
+    if (await health(port, readRouterToken(paths.keyFile))) console.log("Restart the router (stop && start) to drop the in-memory proxy");
+    return;
+  }
+  throw new Error(`Unknown proxy subcommand: ${subcommand}`);
+}
+
 async function doctor(port) {
   const { paths } = runtime();
   const config = existsSync(paths.config) ? readFileSync(paths.config, "utf8") : "";
-  const ready = await health(port);
+  const routerToken = readRouterToken(paths.keyFile);
+  const ready = await health(port, routerToken);
   const checks = {
-    config_injected: config.includes("# DSCodex managed"),
+    config_injected: Boolean(routerToken) && managedRouterConfigMatches(config, {
+      port,
+      catalogPath: paths.catalog,
+      routerToken,
+    }),
     catalog_present: existsSync(paths.catalog),
+    router_token_present: Boolean(routerToken),
     proxy_running: Boolean(ready),
     deepseek_key_in_proxy: Boolean(ready?.deepseek_key),
     // The app-server bridge is macOS-only: Windows GUI apps cannot spawn a script
@@ -467,6 +728,9 @@ Usage: dscodex <command> [--port ${DEFAULT_PORT}]
   key set     store the DeepSeek API key (hidden prompt, or DEEPSEEK_API_KEY env)
   key status  show where the DeepSeek key comes from
   key delete  remove the stored DeepSeek key
+  proxy set   store the outbound proxy for GPT/vision traffic (e.g. http://127.0.0.1:10808)
+  proxy status  show where the proxy comes from
+  proxy clear   remove the stored proxy
   start       run the loopback router in the background
   serve       run the loopback router in the foreground
   autostart enable|disable|status  run the router automatically at login
@@ -477,7 +741,12 @@ Usage: dscodex <command> [--port ${DEFAULT_PORT}]
 
 Key sources, in order: DEEPSEEK_API_KEY env, ~/.codex/dscodex/config.json${
   process.platform === "darwin" ? ", then the macOS launchctl login session" : ""
-}. The stored key survives reboots.`);
+}. The stored key survives reboots.
+
+Proxy sources, in order: DSCODEX_HTTPS_PROXY / DSCODEX_HTTP_PROXY env,
+standard HTTP(S)_PROXY env (lowercase names take precedence), then ~/.codex/dscodex/config.json (proxy set).
+The router re-execs itself with Node's --use-env-proxy (Node >= 24.5); loopback and
+api.deepseek.com stay outside the proxy while GPT passthrough and vision use it.`);
 }
 
 async function main() {
@@ -501,6 +770,7 @@ async function main() {
       break;
     }
     case "key": await manageKey(args[0] ?? "status", paths, port); break;
+    case "proxy": await manageProxy(args[0] ?? "status", args.slice(1), paths, port); break;
     case "start": await start(port); break;
     case "serve": await serve(port); break;
     case "autostart": await manageAutostart(args[0] ?? "status", paths, port); break;

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -8,8 +8,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
-import { MANAGED_MARKER } from "./constants.mjs";
-import { syncCatalog } from "./catalog.mjs";
+import { HOST, MANAGED_MARKER } from "./constants.mjs";
+import { buildCatalog, writeCatalog } from "./catalog.mjs";
+import {
+  createRouterToken,
+  ensureRouterToken,
+  readRouterConfig,
+  readRouterToken,
+} from "./keys.mjs";
 
 const ROOT_KEYS = new Set(["openai_base_url", "model_catalog_json"]);
 const DESKTOP_KEY = "enabled-reasoning-efforts";
@@ -26,6 +32,127 @@ function firstTableIndex(lines) {
 
 function quoteToml(value) {
   return JSON.stringify(value);
+}
+
+function validRouterToken(value) {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+function authenticatedPidState(state) {
+  return Number.isInteger(state?.pid) && state.pid >= 1
+    && Number.isInteger(state.port) && state.port >= 1 && state.port <= 65535
+    && validRouterToken(state.routerToken)
+    && validRouterToken(state.shutdownToken)
+    && typeof state.instanceId === "string"
+    && new RegExp(`^${state.pid}-\\d+-[0-9a-f]{16}$`).test(state.instanceId);
+}
+
+function processAppearsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function assertNoActiveLegacyRouter(paths) {
+  if (!existsSync(paths.pid)) return;
+  let state;
+  try {
+    state = JSON.parse(readFileSync(paths.pid, "utf8"));
+  } catch {
+    throw new Error(
+      `Invalid DSCodex pid state at ${paths.pid}; verify no router is running and remove the file before installing`,
+    );
+  }
+  if (authenticatedPidState(state)) return;
+  if (!Number.isInteger(state?.pid) || state.pid < 1
+    || !Number.isInteger(state.port) || state.port < 1 || state.port > 65535) {
+    throw new Error(
+      `Untrusted DSCodex pid state at ${paths.pid}; verify no router is running and remove the file before installing`,
+    );
+  }
+  if (!processAppearsAlive(state.pid)) return;
+  throw new Error(
+    `A router from an older or untrusted DSCodex state is still running `
+      + `(PID ${state.pid}, port ${state.port}); stop it with the previous DSCodex version before installing`,
+  );
+}
+
+function routerBaseUrl({ port, routerToken }) {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${port}`);
+  }
+  if (!validRouterToken(routerToken)) throw new Error("DSCodex install requires a router token");
+  return `http://${HOST}:${port}/${routerToken}/v1`;
+}
+
+function managedRootLines(options) {
+  return [
+    MANAGED_MARKER,
+    `openai_base_url = ${quoteToml(routerBaseUrl(options))}`,
+    `model_catalog_json = ${quoteToml(options.catalogPath)}`,
+  ];
+}
+
+function assignedString(line) {
+  const equals = line.indexOf("=");
+  if (equals === -1) return "";
+  try {
+    const value = JSON.parse(line.slice(equals + 1).trim());
+    return typeof value === "string" ? value : "";
+  } catch {
+    return "";
+  }
+}
+
+function managedRootBlock(content) {
+  const lines = content.replaceAll("\r\n", "\n").split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== MANAGED_MARKER) continue;
+    let next = index + 1;
+    if (!ROOT_KEYS.has(keyOf(lines[next] ?? ""))) continue;
+    const values = {};
+    while (next < lines.length && ROOT_KEYS.has(keyOf(lines[next]))) {
+      values[keyOf(lines[next])] = assignedString(lines[next]);
+      next += 1;
+    }
+    return { lines, start: index, end: next, values };
+  }
+  return null;
+}
+
+export function readManagedRouterToken(content) {
+  const baseUrl = managedRootBlock(content)?.values.openai_base_url;
+  if (!baseUrl) return "";
+  try {
+    const parsed = new URL(baseUrl);
+    const match = /^\/([A-Za-z0-9_-]{43})\/v1\/?$/.exec(parsed.pathname);
+    if (parsed.protocol !== "http:" || parsed.hostname !== HOST
+      || parsed.username || parsed.password || parsed.search || parsed.hash || !match) return "";
+    return match[1];
+  } catch {
+    return "";
+  }
+}
+
+export function managedRouterConfigMatches(content, options) {
+  const block = managedRootBlock(content);
+  if (!block) return false;
+  return block.values.openai_base_url === routerBaseUrl(options)
+    && block.values.model_catalog_json === options.catalogPath;
+}
+
+function rewriteManagedRouterConfig(content, options) {
+  const block = managedRootBlock(content);
+  if (!block) {
+    throw new Error("DSCodex managed router config is missing; run `node src/cli.mjs install`");
+  }
+  block.lines.splice(block.start, block.end - block.start, ...managedRootLines(options));
+  return block.lines.join("\n");
 }
 
 export function stripManagedConfig(content) {
@@ -58,15 +185,10 @@ function assertNoRootConflict(content) {
   }
 }
 
-function injectRoot(content, { port, catalogPath }) {
+function injectRoot(content, { port, catalogPath, routerToken }) {
   const lines = content.split("\n");
   const insertAt = firstTableIndex(lines);
-  const block = [
-    MANAGED_MARKER,
-    `openai_base_url = "http://127.0.0.1:${port}/v1"`,
-    `model_catalog_json = ${quoteToml(catalogPath)}`,
-  ];
-  lines.splice(insertAt, 0, ...block);
+  lines.splice(insertAt, 0, ...managedRootLines({ port, catalogPath, routerToken }));
   return lines.join("\n");
 }
 
@@ -103,16 +225,58 @@ function atomicWrite(path, content, mode = 0o600) {
   renameSync(temporary, path);
 }
 
+export function ensureManagedRouterBinding({ paths, port }) {
+  // Guard every runtime entry point (start/serve/autostart) before it can
+  // publish an authenticated URL while a pre-authentication router still owns
+  // the port and legacy pid state. `install` performs the same guard separately.
+  assertNoActiveLegacyRouter(paths);
+  const original = existsSync(paths.config) ? readFileSync(paths.config, "utf8") : "";
+  if (!managedRootBlock(original)) {
+    throw new Error("DSCodex managed router config is missing; run `node src/cli.mjs install`");
+  }
+  const routerToken = ensureRouterToken(paths.keyFile, readManagedRouterToken(original));
+  const options = { port, catalogPath: paths.catalog, routerToken };
+  const updated = !managedRouterConfigMatches(original, options);
+  if (updated) {
+    const configured = rewriteManagedRouterConfig(original, options);
+    atomicWrite(paths.config, configured.endsWith("\n") ? configured : `${configured}\n`);
+  }
+  return { routerToken, updated };
+}
+
 export function install({ paths, port }) {
+  // A pre-authentication router cannot understand the new tokenized URL, and
+  // its legacy pid file cannot support authenticated shutdown. Refuse the
+  // upgrade before changing config or generated state; never signal that PID.
+  assertNoActiveLegacyRouter(paths);
   mkdirSync(dirname(paths.config), { recursive: true });
   const original = existsSync(paths.config) ? readFileSync(paths.config, "utf8") : "";
-  const configured = buildInstalledConfig(original, { port, catalogPath: paths.catalog });
-  const catalog = syncCatalog({ cachePath: paths.cache, catalogPath: paths.catalog });
+  // Validate every input before publishing any generated file. In particular,
+  // a corrupt state file must not leave config.toml pointing at an unpersisted token.
+  readRouterConfig(paths.keyFile, { strict: true });
+  const candidateToken = readRouterToken(paths.keyFile)
+    || readManagedRouterToken(original)
+    || createRouterToken();
+  let configured = buildInstalledConfig(original, {
+    port,
+    catalogPath: paths.catalog,
+    routerToken: candidateToken,
+  });
+  const cache = JSON.parse(readFileSync(paths.cache, "utf8"));
+  const catalog = buildCatalog(cache);
   if (!existsSync(paths.backup) && existsSync(paths.config)) {
     copyFileSync(paths.config, paths.backup);
   }
+
+  // Persist the credential used by the loopback router before exposing it in
+  // config.toml. A later failure can leave an unused token, never a broken URL.
+  const routerToken = ensureRouterToken(paths.keyFile, candidateToken);
+  if (routerToken !== candidateToken) {
+    configured = buildInstalledConfig(original, { port, catalogPath: paths.catalog, routerToken });
+  }
+  writeCatalog({ catalogPath: paths.catalog, catalog });
   atomicWrite(paths.config, configured.endsWith("\n") ? configured : `${configured}\n`);
-  return { catalog, configPath: paths.config, catalogPath: paths.catalog };
+  return { catalog, configPath: paths.config, catalogPath: paths.catalog, routerToken };
 }
 
 export function uninstall({ paths }) {

--- a/src/keys.mjs
+++ b/src/keys.mjs
@@ -1,32 +1,55 @@
 import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 
 const FIELD = "deepseek_api_key";
 const ENCODING_FIELD = "key_encoding";
+const PROXY_FIELD = "proxy_url";
+const PROXY_ENCODING_FIELD = "proxy_encoding";
+const ROUTER_TOKEN_FIELD = "router_token";
 const DPAPI = "dpapi";
 const PLAIN = "plain";
 
-// Windows stores the key with DPAPI (CurrentUser scope) so other accounts and
-// casual file reads (backups, copies) cannot recover the plaintext. The same
-// user's router can still decrypt it at startup. Non-Windows keeps the
-// plaintext file (mode 0600) exactly as before.
+function isConfigObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function powershellPath() {
+  return join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+function runDpapi(operation, value) {
+  const encoded = operation === "protect" ? Buffer.from(value, "utf8").toString("base64") : value;
+  const script = [
+    "$inputText = [Console]::In.ReadToEnd().Trim()",
+    "$bytes = [Convert]::FromBase64String($inputText)",
+    "Add-Type -AssemblyName System.Security",
+    operation === "protect"
+      ? "$result = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)"
+      : "$result = [System.Security.Cryptography.ProtectedData]::Unprotect($bytes, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)",
+    "[Console]::Out.Write([Convert]::ToBase64String($result))",
+  ].join("; ");
+  const result = execFileSync(
+    powershellPath(),
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { input: `${encoded}\n`, encoding: "utf8", windowsHide: true },
+  ).trim();
+  return result;
+}
+
 function dpapiProtect(plain) {
-  const encoded = Buffer.from(plain, "utf8").toString("base64");
-  const script = `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Protect([Convert]::FromBase64String('${encoded}'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`;
-  return execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { encoding: "utf8", windowsHide: true }).trim();
+  return runDpapi("protect", plain);
 }
 
 function dpapiUnprotect(encoded) {
-  const script = `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('${encoded}'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`;
-  const base64 = execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { encoding: "utf8", windowsHide: true }).trim();
-  return Buffer.from(base64, "base64").toString("utf8");
+  return Buffer.from(runDpapi("unprotect", encoded), "base64").toString("utf8");
 }
 
 export function readStoredKey(keyFile) {
   if (!existsSync(keyFile)) return "";
   try {
-    const parsed = JSON.parse(readFileSync(keyFile, "utf8"));
+    const parsed = readRouterConfig(keyFile);
     const stored = typeof parsed?.[FIELD] === "string" ? parsed[FIELD].trim() : "";
     if (!stored) return "";
     // Legacy files written before key_encoding existed store the plaintext.
@@ -36,17 +59,130 @@ export function readStoredKey(keyFile) {
   }
 }
 
+// Reads the whole router config file (DeepSeek key, proxy URL, ...) without
+// touching the stored key ciphertext. Corrupt or missing files resolve to {}.
+export function readRouterConfig(keyFile, { strict = false } = {}) {
+  if (!existsSync(keyFile)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(keyFile, "utf8"));
+    if (isConfigObject(parsed)) return parsed;
+    if (strict) throw new Error("DSCodex config must contain a JSON object");
+  } catch (error) {
+    if (strict && error instanceof Error && error.message.startsWith("DSCodex config")) throw error;
+    // JSON.parse includes a fragment of the rejected input in modern Node
+    // versions. Never let that fragment (which may be an API key or proxy
+    // credential) escape through the CLI's top-level error handler.
+    if (strict) throw new Error(`Could not read or parse DSCodex config at ${keyFile}`);
+  }
+  return {};
+}
+
+export function writeRouterConfig(keyFile, config) {
+  if (!isConfigObject(config)) throw new Error("DSCodex config must contain a JSON object");
+  if (Object.keys(config).length === 0) {
+    if (existsSync(keyFile)) unlinkSync(keyFile);
+    return {};
+  }
+  mkdirSync(dirname(keyFile), { recursive: true, mode: 0o700 });
+  const temporary = `${keyFile}.dscodex-tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, keyFile);
+  return config;
+}
+
+function configForWrite(keyFile) {
+  return readRouterConfig(keyFile, { strict: true });
+}
+
 export function writeStoredKey(keyFile, key) {
   const trimmed = key.trim();
   if (!trimmed) throw new Error("Empty DeepSeek API key");
-  mkdirSync(dirname(keyFile), { recursive: true, mode: 0o700 });
   const encoding = process.platform === "win32" ? DPAPI : PLAIN;
   const stored = encoding === DPAPI ? dpapiProtect(trimmed) : trimmed;
-  const temporary = `${keyFile}.dscodex-tmp-${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ [FIELD]: stored, [ENCODING_FIELD]: encoding }, null, 2)}\n`, { mode: 0o600 });
-  renameSync(temporary, keyFile);
+  const config = configForWrite(keyFile);
+  config[FIELD] = stored;
+  config[ENCODING_FIELD] = encoding;
+  writeRouterConfig(keyFile, config);
+}
+
+export function readProxyUrl(keyFile) {
+  const config = readRouterConfig(keyFile);
+  const value = config[PROXY_FIELD];
+  if (typeof value !== "string") return "";
+  try {
+    return config[PROXY_ENCODING_FIELD] === DPAPI ? dpapiUnprotect(value).trim() : value.trim();
+  } catch {
+    return "";
+  }
+}
+
+export function writeProxyUrl(keyFile, proxyUrl) {
+  const trimmed = (proxyUrl ?? "").trim();
+  // Any state-changing command is also an opportunity to remove a legacy
+  // plaintext Windows key, rather than waiting until the router next starts.
+  migrateLegacyStoredKey(keyFile);
+  const config = configForWrite(keyFile);
+  if (trimmed) {
+    const encoding = process.platform === "win32" ? DPAPI : PLAIN;
+    config[PROXY_FIELD] = encoding === DPAPI ? dpapiProtect(trimmed) : trimmed;
+    config[PROXY_ENCODING_FIELD] = encoding;
+  } else {
+    delete config[PROXY_FIELD];
+    delete config[PROXY_ENCODING_FIELD];
+  }
+  writeRouterConfig(keyFile, config);
+}
+
+export function createRouterToken() {
+  return randomBytes(32).toString("base64url");
+}
+
+export function readRouterToken(keyFile) {
+  const value = readRouterConfig(keyFile)[ROUTER_TOKEN_FIELD];
+  return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value) ? value : "";
+}
+
+export function writeRouterToken(keyFile, token) {
+  if (typeof token !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(token)) {
+    throw new Error("Invalid DSCodex router token");
+  }
+  migrateLegacyStoredKey(keyFile);
+  const config = configForWrite(keyFile);
+  config[ROUTER_TOKEN_FIELD] = token;
+  writeRouterConfig(keyFile, config);
+}
+
+export function ensureRouterToken(keyFile, preferredToken = "") {
+  const config = readRouterConfig(keyFile, { strict: true });
+  const existing = config[ROUTER_TOKEN_FIELD];
+  if (typeof existing === "string" && /^[A-Za-z0-9_-]{43}$/.test(existing)) {
+    migrateLegacyStoredKey(keyFile);
+    return existing;
+  }
+  const token = typeof preferredToken === "string" && /^[A-Za-z0-9_-]{43}$/.test(preferredToken)
+    ? preferredToken
+    : createRouterToken();
+  writeRouterToken(keyFile, token);
+  return token;
+}
+
+export function migrateLegacyStoredKey(keyFile) {
+  if (process.platform !== "win32") return false;
+  const config = readRouterConfig(keyFile);
+  if (config[ENCODING_FIELD] === DPAPI
+    || (config[ENCODING_FIELD] && config[ENCODING_FIELD] !== PLAIN)
+    || typeof config[FIELD] !== "string" || !config[FIELD].trim()) return false;
+  writeStoredKey(keyFile, config[FIELD]);
+  return true;
 }
 
 export function deleteStoredKey(keyFile) {
-  if (existsSync(keyFile)) unlinkSync(keyFile);
+  const config = configForWrite(keyFile);
+  delete config[FIELD];
+  delete config[ENCODING_FIELD];
+  if (Object.keys(config).length === 0) {
+    if (existsSync(keyFile)) unlinkSync(keyFile);
+  } else {
+    writeRouterConfig(keyFile, config);
+  }
 }

--- a/src/keys.mjs
+++ b/src/keys.mjs
@@ -1,13 +1,36 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 const FIELD = "deepseek_api_key";
+const ENCODING_FIELD = "key_encoding";
+const DPAPI = "dpapi";
+const PLAIN = "plain";
+
+// Windows stores the key with DPAPI (CurrentUser scope) so other accounts and
+// casual file reads (backups, copies) cannot recover the plaintext. The same
+// user's router can still decrypt it at startup. Non-Windows keeps the
+// plaintext file (mode 0600) exactly as before.
+function dpapiProtect(plain) {
+  const encoded = Buffer.from(plain, "utf8").toString("base64");
+  const script = `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Protect([Convert]::FromBase64String('${encoded}'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`;
+  return execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { encoding: "utf8", windowsHide: true }).trim();
+}
+
+function dpapiUnprotect(encoded) {
+  const script = `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('${encoded}'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`;
+  const base64 = execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { encoding: "utf8", windowsHide: true }).trim();
+  return Buffer.from(base64, "base64").toString("utf8");
+}
 
 export function readStoredKey(keyFile) {
   if (!existsSync(keyFile)) return "";
   try {
     const parsed = JSON.parse(readFileSync(keyFile, "utf8"));
-    return typeof parsed?.[FIELD] === "string" ? parsed[FIELD].trim() : "";
+    const stored = typeof parsed?.[FIELD] === "string" ? parsed[FIELD].trim() : "";
+    if (!stored) return "";
+    // Legacy files written before key_encoding existed store the plaintext.
+    return parsed?.[ENCODING_FIELD] === DPAPI ? dpapiUnprotect(stored) : stored;
   } catch {
     return "";
   }
@@ -17,8 +40,10 @@ export function writeStoredKey(keyFile, key) {
   const trimmed = key.trim();
   if (!trimmed) throw new Error("Empty DeepSeek API key");
   mkdirSync(dirname(keyFile), { recursive: true, mode: 0o700 });
+  const encoding = process.platform === "win32" ? DPAPI : PLAIN;
+  const stored = encoding === DPAPI ? dpapiProtect(trimmed) : trimmed;
   const temporary = `${keyFile}.dscodex-tmp-${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ [FIELD]: trimmed }, null, 2)}\n`, { mode: 0o600 });
+  writeFileSync(temporary, `${JSON.stringify({ [FIELD]: stored, [ENCODING_FIELD]: encoding }, null, 2)}\n`, { mode: 0o600 });
   renameSync(temporary, keyFile);
 }
 

--- a/src/proxy-config.mjs
+++ b/src/proxy-config.mjs
@@ -1,0 +1,125 @@
+// Proxy resolution for the loopback router.
+//
+// Node's global fetch (undici) ignores HTTP_PROXY / HTTPS_PROXY by default, so
+// on networks where chatgpt.com is only reachable through a proxy the router
+// would otherwise fail every GPT passthrough with ECONNRESET while DeepSeek
+// (a directly reachable host) keeps working. The router therefore resolves a
+// proxy explicitly and re-execs itself with --use-env-proxy so both the GPT
+// passthrough and the GPT vision describes use it, while NO_PROXY keeps
+// loopback and api.deepseek.com direct.
+
+const DIRECT_NO_PROXY = ["127.0.0.1", "localhost", "::1", "api.deepseek.com"];
+
+const PROXY_ENV_NAMES = [
+  "DSCODEX_HTTPS_PROXY",
+  "DSCODEX_HTTP_PROXY",
+  "dscodex_https_proxy",
+  "dscodex_http_proxy",
+  "https_proxy",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "HTTP_PROXY",
+];
+
+function valueFromEnv(env, name) {
+  const value = env?.[name];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function resolveProxy(env = process.env, stored = "") {
+  for (const name of PROXY_ENV_NAMES) {
+    const candidate = valueFromEnv(env, name);
+    if (candidate) return candidate;
+  }
+  return typeof stored === "string" ? stored.trim() : "";
+}
+
+export function proxySource(env = process.env, stored = "") {
+  if (PROXY_ENV_NAMES.slice(0, 4).some((name) => valueFromEnv(env, name))) {
+    return "DSCODEX_*_PROXY env";
+  }
+  if (PROXY_ENV_NAMES.slice(4).some((name) => valueFromEnv(env, name))) {
+    return "HTTP(S)_PROXY env";
+  }
+  return typeof stored === "string" && stored.trim() ? "stored in config.json" : "";
+}
+
+// --use-env-proxy landed in Node 24.5.0. Keep the gate conservative: older
+// runtimes get a clear error instead of an unknown-option crash at startup.
+export function envProxySupported(version = process.version) {
+  const match = /^v(\d+)\.(\d+)\./.exec(String(version));
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major > 24 || (major === 24 && minor >= 5);
+}
+
+export function usesEnvProxy(env = process.env) {
+  return /(^|\s)--use-env-proxy(\s|$)/.test(env.NODE_OPTIONS ?? "")
+    || String(env.NODE_USE_ENV_PROXY ?? "") === "1";
+}
+
+export function proxyEnvFor(proxyUrl, env = process.env) {
+  const validated = validateProxyUrl(proxyUrl);
+  const noProxy = mergeNoProxy(`${env.NO_PROXY ?? ""},${env.no_proxy ?? ""}`);
+  return {
+    HTTP_PROXY: validated,
+    HTTPS_PROXY: validated,
+    http_proxy: validated,
+    https_proxy: validated,
+    NO_PROXY: noProxy,
+    no_proxy: noProxy,
+    NODE_OPTIONS: appendEnvProxyFlag(env.NODE_OPTIONS),
+  };
+}
+
+export function validateProxyUrl(value) {
+  const trimmed = String(value ?? "").trim();
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("Invalid proxy URL (expected http:// or https:// with a hostname)");
+  }
+  if (!/^https?:$/.test(parsed.protocol) || !parsed.hostname) {
+    throw new Error("Invalid proxy URL (expected http:// or https:// with a hostname)");
+  }
+  return trimmed;
+}
+
+export function redactProxyUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(String(value));
+  } catch {
+    return "<invalid proxy URL>";
+  }
+  if (parsed.username || parsed.password) {
+    if (parsed.username) parsed.username = "redacted";
+    if (parsed.password) parsed.password = "redacted";
+  }
+  if (parsed.search) parsed.search = "?redacted";
+  if (parsed.hash) parsed.hash = "#redacted";
+  return parsed.toString();
+}
+
+function appendEnvProxyFlag(nodeOptions = "") {
+  const trimmed = String(nodeOptions).trim();
+  if (usesEnvProxy({ NODE_OPTIONS: trimmed })) return trimmed;
+  return trimmed ? `${trimmed} --use-env-proxy` : "--use-env-proxy";
+}
+
+function mergeNoProxy(existing = "") {
+  const parts = String(existing)
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const seen = new Set(parts.map((part) => part.toLowerCase()));
+  for (const value of DIRECT_NO_PROXY) {
+    if (!seen.has(value.toLowerCase())) {
+      parts.push(value);
+      seen.add(value.toLowerCase());
+    }
+  }
+  return parts.join(",");
+}

--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { timingSafeEqual } from "node:crypto";
 import { brotliDecompressSync, gunzipSync, inflateSync, zstdDecompressSync } from "node:zlib";
 import { Readable } from "node:stream";
 import {
@@ -43,6 +44,11 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+const DEFAULT_MAX_REQUEST_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_DECODED_BYTES = 128 * 1024 * 1024;
+const SHUTDOWN_HEADER = "x-dscodex-shutdown-token";
+const SHUTDOWN_PATH = "/_dscodex/shutdown";
+
 function isDeepSeekModel(model) {
   return model === DEEPSEEK_PICKER_SLUG || model === DEEPSEEK_WIRE_MODEL;
 }
@@ -79,22 +85,57 @@ export function buildDeepSeekBody(input) {
   return body;
 }
 
-function decodeBody(buffer, encoding) {
+function decodeBody(buffer, encoding, maxOutputLength) {
+  const options = { maxOutputLength };
   switch ((encoding ?? "").toLowerCase()) {
-    case "gzip": return gunzipSync(buffer);
-    case "deflate": return inflateSync(buffer);
-    case "br": return brotliDecompressSync(buffer);
-    case "zstd": return zstdDecompressSync(buffer);
+    case "gzip": return gunzipSync(buffer, options);
+    case "deflate": return inflateSync(buffer, options);
+    case "br": return brotliDecompressSync(buffer, options);
+    case "zstd": return zstdDecompressSync(buffer, options);
     case "":
     case "identity": return buffer;
     default: throw new Error(`Unsupported content-encoding: ${encoding}`);
   }
 }
 
-async function readRequestBody(request) {
+async function readRequestBody(request, maxBytes) {
+  const declared = Number(request.headers["content-length"]);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    request.resume();
+    const error = new Error("Request body exceeds the configured limit");
+    error.statusCode = 413;
+    throw error;
+  }
   const chunks = [];
-  for await (const chunk of request) chunks.push(chunk);
+  let total = 0;
+  for await (const chunk of request) {
+    total += chunk.length;
+    if (total > maxBytes) {
+      request.resume();
+      const error = new Error("Request body exceeds the configured limit");
+      error.statusCode = 413;
+      throw error;
+    }
+    chunks.push(chunk);
+  }
   return Buffer.concat(chunks);
+}
+
+function validRouterToken(token) {
+  return typeof token === "string" && /^[A-Za-z0-9_-]{43}$/.test(token);
+}
+
+function tokenMatches(candidate, expected) {
+  const actual = Buffer.from(candidate ?? "", "utf8");
+  const target = Buffer.from(expected, "utf8");
+  return actual.length === target.length && timingSafeEqual(actual, target);
+}
+
+function authorizedPath(pathname, routerToken) {
+  const firstSlash = pathname.indexOf("/", 1);
+  const candidate = firstSlash === -1 ? pathname.slice(1) : pathname.slice(1, firstSlash);
+  if (!tokenMatches(candidate, routerToken)) return null;
+  return firstSlash === -1 ? "/" : pathname.slice(firstSlash) || "/";
 }
 
 function copyRequestHeaders(request, deepSeekKey) {
@@ -135,16 +176,51 @@ export function createProxyServer({
   models = [],
   logger = console,
   visionModel,
+  routerToken,
+  shutdownToken = "",
+  instanceId = "",
+  onShutdown,
+  maxRequestBytes = DEFAULT_MAX_REQUEST_BYTES,
+  maxDecodedBytes = DEFAULT_MAX_DECODED_BYTES,
 } = {}) {
+  if (!validRouterToken(routerToken)) throw new Error("DSCodex routerToken is required");
+  if (shutdownToken && !validRouterToken(shutdownToken)) throw new Error("Invalid DSCodex shutdownToken");
   const vision = createVisionDescriber({ baseUrl: chatGptBaseUrl, model: visionModel, logger });
   const server = http.createServer(async (request, response) => {
     const startedAt = Date.now();
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
-    if (request.method === "GET" && url.pathname === "/health") {
-      json(response, 200, { ok: true, deepseek_key: Boolean(deepSeekKey) });
+    const pathname = authorizedPath(url.pathname, routerToken);
+    if (!pathname) {
+      json(response, 404, { error: { message: "Not found" } });
       return;
     }
-    if (request.method === "GET" && (url.pathname === "/models" || url.pathname === "/v1/models")) {
+    if (request.method === "POST" && pathname === SHUTDOWN_PATH) {
+      request.resume();
+      if (!shutdownToken || !tokenMatches(request.headers[SHUTDOWN_HEADER], shutdownToken)) {
+        json(response, 401, { error: { message: "Invalid shutdown token" } });
+        return;
+      }
+      json(response, 202, { ok: true });
+      if (typeof onShutdown === "function") {
+        setImmediate(() => {
+          try {
+            onShutdown();
+          } catch (error) {
+            logger.error?.(`shutdown failed: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        });
+      }
+      return;
+    }
+    if (request.method === "GET" && pathname === "/health") {
+      json(response, 200, {
+        ok: true,
+        deepseek_key: Boolean(deepSeekKey),
+        ...(instanceId ? { instance_id: instanceId } : {}),
+      });
+      return;
+    }
+    if (request.method === "GET" && (pathname === "/models" || pathname === "/v1/models")) {
       json(response, 200, { models });
       return;
     }
@@ -153,35 +229,39 @@ export function createProxyServer({
       return;
     }
 
+    let direction = "unknown";
     try {
-      const raw = await readRequestBody(request);
-      const decoded = decodeBody(raw, request.headers["content-encoding"]);
+      const raw = await readRequestBody(request, maxRequestBytes);
+      let decoded;
+      try {
+        decoded = decodeBody(raw, request.headers["content-encoding"], maxDecodedBytes);
+      } catch (error) {
+        if (error?.code === "ERR_BUFFER_TOO_LARGE") error.statusCode = 413;
+        throw error;
+      }
+      if (decoded.length > maxDecodedBytes) {
+        const error = new Error("Decoded request body exceeds the configured limit");
+        error.statusCode = 413;
+        throw error;
+      }
       const parsed = JSON.parse(decoded.toString("utf8"));
       const deepSeek = isDeepSeekModel(parsed.model);
+      direction = deepSeek ? "deepseek" : "chatgpt";
       if (deepSeek && !deepSeekKey) {
         json(response, 503, { error: { message: "DEEPSEEK_API_KEY is not configured in the DSCodex server process" } });
         return;
       }
-      // The loopback port injects the stored DeepSeek key upstream, so it must
-      // not answer anonymous callers (browsers, sandboxed processes, or other
-      // local tools). The stock Codex client always sends its own credentials
-      // (ChatGPT OAuth or an API key), which is enough to pass this gate.
-      if (deepSeek && !request.headers.authorization?.trim()) {
-        json(response, 401, { error: { message: "Missing authorization header: the Codex client must authenticate before the local router can use the DeepSeek key" } });
-        return;
-      }
-
       let outgoingBody = raw;
       if (deepSeek) {
         const body = buildDeepSeekBody(parsed);
         // DeepSeek V4 is text-only: borrow the caller's GPT OAuth to describe any
         // attached images, then inject the descriptions as plain input_text.
         const rewritten = await vision.rewriteImages(body, request.headers);
-        if (rewritten) logger.info?.(`vision: described ${rewritten} image(s) for ${url.pathname}`);
+        if (rewritten) logger.info?.(`vision: described ${rewritten} image(s) for ${pathname}`);
         outgoingBody = Buffer.from(JSON.stringify(body));
       }
       const baseUrl = deepSeek ? deepSeekBaseUrl : chatGptBaseUrl;
-      const target = new URL(`${baseUrl.replace(/\/$/, "")}${upstreamPath(url.pathname)}${url.search}`);
+      const target = new URL(`${baseUrl.replace(/\/$/, "")}${upstreamPath(pathname)}${url.search}`);
       const headers = copyRequestHeaders(request, deepSeek ? deepSeekKey : undefined);
       if (!deepSeek && request.headers["content-encoding"]) {
         headers.set("content-encoding", request.headers["content-encoding"]);
@@ -204,7 +284,7 @@ export function createProxyServer({
       response.statusCode = upstream.status;
       response.statusMessage = upstream.statusText;
       copyResponseHeaders(upstream, response);
-      logger.info?.(`${deepSeek ? "deepseek" : "chatgpt"} ${url.pathname} -> ${upstream.status} ${Date.now() - startedAt}ms`);
+      logger.info?.(`${deepSeek ? "deepseek" : "chatgpt"} ${pathname} -> ${upstream.status} ${Date.now() - startedAt}ms`);
       if (!upstream.body) {
         response.end();
         return;
@@ -218,9 +298,10 @@ export function createProxyServer({
       });
       stream.pipe(response);
     } catch (error) {
-      logger.error?.(`proxy error: ${error instanceof Error ? error.message : String(error)}`);
+      logger.error?.(`proxy error (${direction} ${pathname}): ${error instanceof Error ? error.message : String(error)}`);
       if (!response.headersSent && !response.destroyed) {
-        json(response, 502, { error: { message: "DSCodex upstream request failed" } });
+        const status = Number.isInteger(error?.statusCode) ? error.statusCode : 502;
+        json(response, status, { error: { message: status === 413 ? "Request body too large" : "DSCodex upstream request failed" } });
       } else {
         response.destroy(error instanceof Error ? error : undefined);
       }

--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -162,6 +162,14 @@ export function createProxyServer({
         json(response, 503, { error: { message: "DEEPSEEK_API_KEY is not configured in the DSCodex server process" } });
         return;
       }
+      // The loopback port injects the stored DeepSeek key upstream, so it must
+      // not answer anonymous callers (browsers, sandboxed processes, or other
+      // local tools). The stock Codex client always sends its own credentials
+      // (ChatGPT OAuth or an API key), which is enough to pass this gate.
+      if (deepSeek && !request.headers.authorization?.trim()) {
+        json(response, 401, { error: { message: "Missing authorization header: the Codex client must authenticate before the local router can use the DeepSeek key" } });
+        return;
+      }
 
       let outgoingBody = raw;
       if (deepSeek) {

--- a/test/autostart.test.mjs
+++ b/test/autostart.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -10,8 +13,72 @@ import {
   buildSystemdUnit,
   buildWindowsVbs,
 } from "../src/autostart.mjs";
+import { buildInstalledConfig } from "../src/config.mjs";
+import { pathsFor } from "../src/constants.mjs";
+import { ensureRouterToken } from "../src/keys.mjs";
 
 const CLI = fileURLToPath(new URL("../src/cli.mjs", import.meta.url));
+
+function routerEnv(codexHome, source = process.env) {
+  const env = { ...source, CODEX_HOME: codexHome };
+  // Keep this case-insensitive so Linux/macOS CI with lowercase proxy names
+  // exercises the intended direct serve process instead of its proxy re-exec.
+  for (const name of Object.keys(env)) {
+    if (/^(?:DSCODEX_)?HTTPS?_PROXY$/i.test(name)) delete env[name];
+  }
+  delete env.DSCODEX_PROXY_REEXEC;
+  return env;
+}
+
+function prepareRouterHome(codexHome, port) {
+  const paths = pathsFor(codexHome);
+  const routerToken = ensureRouterToken(paths.keyFile);
+  const config = buildInstalledConfig("", {
+    port,
+    catalogPath: paths.catalog,
+    routerToken,
+  });
+  writeFileSync(paths.config, config.endsWith("\n") ? config : `${config}\n`);
+  return paths;
+}
+
+async function waitForFile(path, message = "file") {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${message}`);
+}
+
+async function waitForPortToClose(port) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const closed = await new Promise((resolve) => {
+      const socket = createConnection({ host: "127.0.0.1", port });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(false);
+      });
+      socket.once("error", () => resolve(true));
+    });
+    if (closed) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("Timed out waiting for the router port to close");
+}
+
+function runCli(args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    child.once("exit", (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
 
 test("launchd plist embeds absolute paths and restarts only on failure", () => {
   const plist = buildLaunchdPlist({
@@ -53,29 +120,61 @@ test("systemd unit quotes paths and restarts on failure only", () => {
   assert.ok(unit.includes("StandardOutput=append:/u/.codex/dscodex/server.log"));
 });
 
-test("windows vbs hides the console and appends to the router log", () => {
+test("windows vbs hides the console via PowerShell and quotes paths safely", () => {
   const vbs = buildWindowsVbs({
     nodePath: "C:\\Program Files\\nodejs\\node.exe",
     cliPath: "C:\\x\\src\\cli.mjs",
     port: 10110,
     logPath: "C:\\u\\server.log",
   });
-  assert.ok(vbs.startsWith('CreateObject("Wscript.Shell").Run "'));
-  assert.ok(vbs.includes('""C:\\Program Files\\nodejs\\node.exe""'));
+  assert.match(vbs, /CreateObject\("Wscript\.Shell"\)\.Run ""?[^\r\n]*System32\\WindowsPowerShell\\v1\.0\\powershell\.exe/);
+  assert.ok(vbs.includes("& 'C:\\Program Files\\nodejs\\node.exe' 'C:\\x\\src\\cli.mjs' serve --port 10110 *>> 'C:\\u\\server.log'"));
   assert.ok(vbs.includes("serve --port 10110"));
-  assert.ok(vbs.includes('>> ""C:\\u\\server.log"" 2>&1'));
-  assert.ok(vbs.trimEnd().endsWith(", 0, False"));
+  assert.ok(vbs.trimEnd().endsWith('"", 0, False'));
+  assert.ok(!vbs.includes("cmd /c"));
 });
 
-test("windows vbs rewrites home-relative log paths to %USERPROFILE% for non-ASCII homes", () => {
+test("windows vbs escapes single quotes and is immune to cmd metacharacters in paths", () => {
+  const vbs = buildWindowsVbs({
+    nodePath: "C:\\a&b\\node.exe",
+    cliPath: "C:\\o'h\\cli.mjs",
+    port: 10110,
+    logPath: "C:\\u|v\\server.log",
+  });
+  assert.ok(vbs.includes("'C:\\a&b\\node.exe'"));
+  assert.ok(vbs.includes("'C:\\o''h\\cli.mjs'"));
+  assert.ok(vbs.includes("'C:\\u|v\\server.log'"));
+  assert.ok(!vbs.includes("cmd /c"));
+});
+
+test("windows vbs rejects invalid ports", () => {
+  assert.throws(
+    () => buildWindowsVbs({ nodePath: "n", cliPath: "c", port: 99999, logPath: "l" }),
+    /Invalid port/,
+  );
+});
+
+test("router test environment removes proxy variables case-insensitively", () => {
+  const env = routerEnv("/tmp/codex", {
+    https_proxy: "http://lower.example",
+    dscodex_http_proxy: "http://custom.example",
+    KEEP_ME: "yes",
+  });
+  assert.equal(env.https_proxy, undefined);
+  assert.equal(env.dscodex_http_proxy, undefined);
+  assert.equal(env.KEEP_ME, "yes");
+});
+
+test("windows vbs resolves home-relative paths at runtime for non-ASCII homes", () => {
   const vbs = buildWindowsVbs({
     nodePath: "C:\\Program Files\\nodejs\\node.exe",
-    cliPath: "C:\\x\\src\\cli.mjs",
+    cliPath: "C:\\Users\\王小明\\DSCodex\\src\\cli.mjs",
     port: 10110,
     logPath: "C:\\Users\\王小明\\.codex\\dscodex\\server.log",
     homeDir: "C:\\Users\\王小明",
   });
-  assert.ok(vbs.includes('>> ""%USERPROFILE%\\.codex\\dscodex\\server.log"" 2>&1'));
+  assert.ok(vbs.includes("$env:USERPROFILE + '\\DSCodex\\src\\cli.mjs'"));
+  assert.ok(vbs.includes("$env:USERPROFILE + '\\.codex\\dscodex\\server.log'"));
   assert.equal(vbs.match(/[^\x00-\x7F]/g), null);
 });
 
@@ -87,37 +186,150 @@ test("windows vbs keeps literal log paths outside the user home", () => {
     logPath: "D:\\logs\\server.log",
     homeDir: "C:\\Users\\王小明",
   });
-  assert.ok(vbs.includes('>> ""D:\\logs\\server.log"" 2>&1'));
+  assert.ok(vbs.includes("*>> 'D:\\logs\\server.log'"));
 });
 
 test("serve owns its pid file across start and graceful shutdown", { timeout: 20_000 }, async () => {
   const codexHome = mkdtempSync(join(tmpdir(), "dscodex-serve-"));
   const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const env = routerEnv(codexHome);
   const child = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
-    env: { ...process.env, CODEX_HOME: codexHome },
+    env,
     stdio: ["ignore", "ignore", "pipe"],
   });
+  const exited = once(child, "exit");
   let stderr = "";
   child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
-  const pidFile = join(codexHome, "dscodex", "server.pid");
   try {
-    let attempts = 0;
-    while (!existsSync(pidFile) && attempts < 50) {
-      attempts += 1;
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    assert.ok(existsSync(pidFile), `pid file never appeared${stderr ? `: ${stderr.trim()}` : ""}`);
-    assert.equal(JSON.parse(readFileSync(pidFile, "utf8")).pid, child.pid);
+    await waitForFile(paths.pid, `pid file${stderr ? `: ${stderr.trim()}` : ""}`);
+    assert.equal(JSON.parse(readFileSync(paths.pid, "utf8")).pid, child.pid);
 
-    child.kill("SIGTERM");
-    const [code] = await new Promise((resolve) => child.once("exit", (exitCode, signal) => resolve([exitCode, signal])));
-    if (process.platform !== "win32") {
-      // Windows terminates the process outright, so there is no graceful exit there.
-      assert.equal(code, 0);
-      assert.equal(existsSync(pidFile), false);
-    }
+    const stopper = spawnSync(process.execPath, [CLI, "stop", "--port", String(port)], {
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(stopper.status, 0, `${stopper.stdout}\n${stopper.stderr}`);
+    const [code] = await exited;
+    assert.equal(code, 0);
+    assert.equal(existsSync(paths.pid), false);
   } finally {
     child.kill("SIGKILL");
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("loopback status and shutdown bypass an enabled environment proxy", { timeout: 20_000 }, async () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-control-direct-"));
+  const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const directEnv = routerEnv(codexHome);
+  delete directEnv.NODE_OPTIONS;
+  delete directEnv.NODE_USE_ENV_PROXY;
+  const child = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
+    env: directEnv,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const routerExited = once(child, "exit");
+  let proxyHits = 0;
+  const fakeProxy = createServer((_request, response) => {
+    proxyHits += 1;
+    response.writeHead(502, { connection: "close" });
+    response.end();
+  });
+  fakeProxy.on("connect", (_request, socket) => {
+    proxyHits += 1;
+    socket.end("HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+  });
+  fakeProxy.listen(0, "127.0.0.1");
+  await once(fakeProxy, "listening");
+  try {
+    await waitForFile(paths.pid, "router pid file");
+    const proxyUrl = `http://127.0.0.1:${fakeProxy.address().port}`;
+    const proxiedEnv = {
+      ...directEnv,
+      NODE_OPTIONS: "--use-env-proxy",
+      HTTP_PROXY: proxyUrl,
+      HTTPS_PROXY: proxyUrl,
+      http_proxy: proxyUrl,
+      https_proxy: proxyUrl,
+      NO_PROXY: "",
+      no_proxy: "",
+    };
+
+    const status = await runCli(["status", "--port", String(port)], proxiedEnv);
+    assert.equal(status.code, 0, `${status.stdout}\n${status.stderr}`);
+    assert.match(status.stdout, /running/);
+
+    const stopped = await runCli(["stop", "--port", String(port)], proxiedEnv);
+    assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
+    const [routerCode] = await routerExited;
+    assert.equal(routerCode, 0);
+    assert.equal(proxyHits, 0);
+  } finally {
+    child.kill("SIGKILL");
+    fakeProxy.closeAllConnections?.();
+    await new Promise((resolve) => fakeProxy.close(resolve));
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("stop preserves pid state written by a replacement instance", { timeout: 20_000 }, async () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-stop-race-"));
+  const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const env = routerEnv(codexHome);
+  const child = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
+    env,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const routerExited = once(child, "exit");
+  let stopper;
+  let heldSocket;
+  try {
+    await waitForFile(paths.pid, "old router pid file");
+    const oldState = JSON.parse(readFileSync(paths.pid, "utf8"));
+
+    // Keep one request active after server.close() releases the listening port,
+    // creating the window in which a replacement can publish its own pid state.
+    heldSocket = createConnection({ host: "127.0.0.1", port });
+    await once(heldSocket, "connect");
+    heldSocket.on("error", () => {});
+    heldSocket.write([
+      `POST /${oldState.routerToken}/v1/responses HTTP/1.1`,
+      `Host: 127.0.0.1:${port}`,
+      "Content-Type: application/json",
+      "Content-Length: 100",
+      "Connection: keep-alive",
+      "",
+      "{",
+    ].join("\r\n"));
+
+    stopper = spawn(process.execPath, [CLI, "stop", "--port", String(port)], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stopperExited = once(stopper, "exit");
+    await waitForPortToClose(port);
+
+    const replacement = {
+      ...oldState,
+      pid: process.pid,
+      instanceId: `${process.pid}-${Date.now()}-${"f".repeat(16)}`,
+    };
+    writeFileSync(paths.pid, `${JSON.stringify(replacement)}\n`, { mode: 0o600 });
+    heldSocket.destroy();
+    heldSocket = null;
+
+    const [[routerCode], [stopCode]] = await Promise.all([routerExited, stopperExited]);
+    assert.equal(routerCode, 0);
+    assert.equal(stopCode, 0);
+    assert.equal(existsSync(paths.pid), true);
+    assert.deepEqual(JSON.parse(readFileSync(paths.pid, "utf8")), replacement);
+  } finally {
+    heldSocket?.destroy();
+    child.kill("SIGKILL");
+    stopper?.kill("SIGKILL");
     rmSync(codexHome, { recursive: true, force: true });
   }
 });

--- a/test/autostart.test.mjs
+++ b/test/autostart.test.mjs
@@ -219,6 +219,43 @@ test("serve owns its pid file across start and graceful shutdown", { timeout: 20
   }
 });
 
+test("proxy re-exec forwards termination to the actual router process", {
+  timeout: 20_000,
+  skip: process.platform === "win32" ? "Windows child.kill does not deliver catchable signals" : false,
+}, async () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-proxy-reexec-"));
+  const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const env = {
+    ...routerEnv(codexHome),
+    DSCODEX_HTTP_PROXY: "http://127.0.0.1:1",
+  };
+  const parent = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
+    env,
+    stdio: "ignore",
+  });
+  const parentExited = once(parent, "exit");
+  let routerPid;
+  try {
+    await waitForFile(paths.pid, "proxy re-exec router pid file");
+    routerPid = JSON.parse(readFileSync(paths.pid, "utf8")).pid;
+    assert.notEqual(routerPid, parent.pid);
+
+    parent.kill("SIGTERM");
+    const [code, signal] = await parentExited;
+    assert.equal(code, 0);
+    assert.equal(signal, null);
+    await waitForPortToClose(port);
+    assert.equal(existsSync(paths.pid), false);
+  } finally {
+    try { parent.kill("SIGKILL"); } catch {}
+    if (routerPid) {
+      try { process.kill(routerPid, "SIGKILL"); } catch {}
+    }
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("loopback status and shutdown bypass an enabled environment proxy", { timeout: 20_000 }, async () => {
   const codexHome = mkdtempSync(join(tmpdir(), "dscodex-control-direct-"));
   const port = 20_000 + Math.floor(Math.random() * 20_000);

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -4,8 +4,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { buildCatalog } from "../src/catalog.mjs";
-import { buildInstalledConfig, install, stripManagedConfig, uninstall } from "../src/config.mjs";
+import {
+  buildInstalledConfig,
+  ensureManagedRouterBinding,
+  install,
+  managedRouterConfigMatches,
+  readManagedRouterToken,
+  stripManagedConfig,
+  uninstall,
+} from "../src/config.mjs";
 import { pathsFor } from "../src/constants.mjs";
+import { readRouterToken, readStoredKey } from "../src/keys.mjs";
 
 const TEMPLATE = {
   slug: "gpt-5.6-sol",
@@ -21,6 +30,8 @@ const TEMPLATE = {
   model_messages: { instructions_template: "You are Codex, an agent based on GPT-5." },
 };
 
+const ROUTER_TOKEN = "A".repeat(43);
+
 test("catalog adds one whale-labelled V4 Flash entry with honest reasoning levels", () => {
   const catalog = buildCatalog({ models: [TEMPLATE] });
   const model = catalog.models[0];
@@ -35,11 +46,82 @@ test("catalog adds one whale-labelled V4 Flash entry with honest reasoning level
 
 test("config injection is root-correct, reversible, and preserves user config", () => {
   const original = 'personality = "pragmatic"\n\n[features]\nmulti_agent = true\n\n[desktop]\ntheme = "light"\n';
-  const installed = buildInstalledConfig(original, { port: 10110, catalogPath: "/tmp/models.json" });
+  const installed = buildInstalledConfig(original, { port: 10110, catalogPath: "/tmp/models.json", routerToken: ROUTER_TOKEN });
   assert.ok(installed.indexOf("openai_base_url") < installed.indexOf("[features]"));
   assert.match(installed, /model_catalog_json = "\/tmp\/models\.json"/);
   assert.match(installed, /enabled-reasoning-efforts = \[.*"max".*\]/);
+  assert.equal(readManagedRouterToken(installed), ROUTER_TOKEN);
+  assert.equal(managedRouterConfigMatches(installed, {
+    port: 10110,
+    catalogPath: "/tmp/models.json",
+    routerToken: ROUTER_TOKEN,
+  }), true);
   assert.equal(stripManagedConfig(installed), original);
+});
+
+test("managed router binding upgrades a legacy URL and preserves user config", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-binding-"));
+  const paths = pathsFor(codexHome);
+  const original = [
+    'personality = "pragmatic"',
+    "# DSCodex managed; remove with `dscodex uninstall`",
+    'openai_base_url = "http://127.0.0.1:10110/v1"',
+    `model_catalog_json = ${JSON.stringify(paths.catalog)}`,
+    "",
+    "[features]",
+    "multi_agent = true",
+    "",
+  ].join("\n");
+  writeFileSync(paths.config, original);
+
+  const result = ensureManagedRouterBinding({ paths, port: 10110 });
+  const updated = readFileSync(paths.config, "utf8");
+  assert.equal(result.updated, true);
+  assert.equal(readRouterToken(paths.keyFile), result.routerToken);
+  assert.equal(readManagedRouterToken(updated), result.routerToken);
+  assert.equal(managedRouterConfigMatches(updated, {
+    port: 10110,
+    catalogPath: paths.catalog,
+    routerToken: result.routerToken,
+  }), true);
+  assert.match(updated, /personality = "pragmatic"/);
+  assert.match(updated, /\[features\]\nmulti_agent = true/);
+});
+
+test("managed router binding refuses a running legacy router before mutation", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-binding-legacy-router-"));
+  const paths = pathsFor(codexHome);
+  const original = [
+    "# DSCodex managed; remove with `dscodex uninstall`",
+    'openai_base_url = "http://127.0.0.1:10110/v1"',
+    `model_catalog_json = ${JSON.stringify(paths.catalog)}`,
+    "",
+  ].join("\n");
+  writeFileSync(paths.config, original);
+  mkdirSync(paths.stateDir, { recursive: true });
+  writeFileSync(paths.pid, `${JSON.stringify({ pid: process.pid, port: 10110 })}\n`);
+
+  assert.throws(
+    () => ensureManagedRouterBinding({ paths, port: 10110 }),
+    /older or untrusted DSCodex state is still running/,
+  );
+  assert.equal(readFileSync(paths.config, "utf8"), original);
+  assert.equal(existsSync(paths.keyFile), false);
+});
+
+test("managed router binding adopts the installed URL token when state is missing", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-binding-"));
+  const paths = pathsFor(codexHome);
+  writeFileSync(paths.config, `${buildInstalledConfig("", {
+    port: 10110,
+    catalogPath: paths.catalog,
+    routerToken: ROUTER_TOKEN,
+  })}\n`);
+
+  const result = ensureManagedRouterBinding({ paths, port: 10110 });
+  assert.equal(result.updated, false);
+  assert.equal(result.routerToken, ROUTER_TOKEN);
+  assert.equal(readRouterToken(paths.keyFile), ROUTER_TOKEN);
 });
 
 test("install and uninstall touch only DSCodex-owned files and lines", () => {
@@ -51,6 +133,9 @@ test("install and uninstall touch only DSCodex-owned files and lines", () => {
 
   const result = install({ paths, port: 10110 });
   assert.equal(result.catalog.models.length, 2);
+  assert.match(result.routerToken, /^[A-Za-z0-9_-]{43}$/);
+  assert.equal(readRouterToken(paths.keyFile), result.routerToken);
+  assert.match(readFileSync(paths.config, "utf8"), new RegExp(`127\\.0\\.0\\.1:10110/${result.routerToken}/v1`));
   assert.equal(existsSync(paths.backup), true);
   assert.equal(existsSync(paths.catalog), true);
   assert.match(readFileSync(paths.config, "utf8"), /DSCodex managed/);
@@ -68,7 +153,74 @@ test("install and uninstall touch only DSCodex-owned files and lines", () => {
 
 test("refuses to replace a user-owned openai_base_url", () => {
   assert.throws(
-    () => buildInstalledConfig('openai_base_url = "https://example.test/v1"\n', { port: 10110, catalogPath: "/tmp/models.json" }),
+    () => buildInstalledConfig('openai_base_url = "https://example.test/v1"\n', { port: 10110, catalogPath: "/tmp/models.json", routerToken: ROUTER_TOKEN }),
     /user-owned root key/,
   );
+});
+
+test("does not install an unauthenticated loopback base URL", () => {
+  assert.throws(
+    () => buildInstalledConfig("", { port: 10110, catalogPath: "/tmp/models.json" }),
+    /requires a router token/,
+  );
+});
+
+test("install validates router state before changing config or catalog", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-install-failure-"));
+  const paths = pathsFor(codexHome);
+  const original = "[features]\nmulti_agent = true\n";
+  const sensitiveCorruptState = "sk-FAKE-REVIEW-SECRET";
+  writeFileSync(paths.config, original);
+  writeFileSync(paths.cache, JSON.stringify({ models: [TEMPLATE] }));
+  mkdirSync(paths.stateDir, { recursive: true });
+  writeFileSync(paths.keyFile, sensitiveCorruptState);
+
+  assert.throws(
+    () => install({ paths, port: 10110 }),
+    (error) => {
+      assert.match(error.message, /Could not read or parse DSCodex config/);
+      assert.doesNotMatch(error.message, /FAKE-REVIEW-SECRET/);
+      return true;
+    },
+  );
+  assert.equal(readFileSync(paths.config, "utf8"), original);
+  assert.equal(existsSync(paths.catalog), false);
+  assert.equal(readFileSync(paths.keyFile, "utf8"), sensitiveCorruptState);
+});
+
+test("install refuses a running legacy router before publishing authenticated state", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-install-legacy-router-"));
+  const paths = pathsFor(codexHome);
+  const original = [
+    "# DSCodex managed; remove with `dscodex uninstall`",
+    'openai_base_url = "http://127.0.0.1:10110/v1"',
+    `model_catalog_json = ${JSON.stringify(paths.catalog)}`,
+    "",
+  ].join("\n");
+  writeFileSync(paths.config, original);
+  writeFileSync(paths.cache, JSON.stringify({ models: [TEMPLATE] }));
+  mkdirSync(paths.stateDir, { recursive: true });
+  writeFileSync(paths.pid, `${JSON.stringify({ pid: process.pid, port: 10110 })}\n`);
+
+  assert.throws(
+    () => install({ paths, port: 10110 }),
+    /older or untrusted DSCodex state is still running/,
+  );
+  assert.equal(readFileSync(paths.config, "utf8"), original);
+  assert.equal(existsSync(paths.catalog), false);
+  assert.equal(existsSync(paths.keyFile), false);
+  assert.equal(existsSync(paths.backup), false);
+});
+
+test("install migrates a legacy Windows plaintext key before returning", () => {
+  if (process.platform !== "win32") return;
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-install-migration-"));
+  const paths = pathsFor(codexHome);
+  mkdirSync(paths.stateDir, { recursive: true });
+  writeFileSync(paths.keyFile, `${JSON.stringify({ deepseek_api_key: "legacy-install-key" })}\n`);
+  writeFileSync(paths.cache, JSON.stringify({ models: [TEMPLATE] }));
+
+  install({ paths, port: 10110 });
+  assert.equal(readStoredKey(paths.keyFile), "legacy-install-key");
+  assert.equal(readFileSync(paths.keyFile, "utf8").includes("legacy-install-key"), false);
 });

--- a/test/keys.test.mjs
+++ b/test/keys.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,7 +11,23 @@ test("stored key roundtrips with owner-only file permissions", () => {
   const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
   writeStoredKey(keyFile, "  sk-test-123  ");
   assert.equal(readStoredKey(keyFile), "sk-test-123");
-  assert.equal(statSync(keyFile).mode & 0o777, 0o600);
+  // Windows has no POSIX mode bits; the file is protected by the account ACL
+  // (and, since the DPAPI change, the ciphertext itself).
+  if (process.platform !== "win32") {
+    assert.equal(statSync(keyFile).mode & 0o777, 0o600);
+  }
+});
+
+test("key file never stores the plaintext on Windows", () => {
+  const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
+  writeStoredKey(keyFile, "sk-test-123");
+  const raw = readFileSync(keyFile, "utf8");
+  if (process.platform === "win32") {
+    assert.equal(raw.includes("sk-test-123"), false);
+  } else {
+    assert.ok(raw.includes("sk-test-123"));
+  }
+  assert.equal(readStoredKey(keyFile), "sk-test-123");
 });
 
 test("missing or corrupt key files resolve to empty", () => {

--- a/test/keys.test.mjs
+++ b/test/keys.test.mjs
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { uninstall } from "../src/config.mjs";
 import { pathsFor } from "../src/constants.mjs";
-import { deleteStoredKey, readStoredKey, writeStoredKey } from "../src/keys.mjs";
+import {
+  deleteStoredKey,
+  ensureRouterToken,
+  migrateLegacyStoredKey,
+  readRouterToken,
+  readProxyUrl,
+  readStoredKey,
+  writeProxyUrl,
+  writeStoredKey,
+} from "../src/keys.mjs";
 
 test("stored key roundtrips with owner-only file permissions", () => {
   const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
@@ -54,4 +63,57 @@ test("deleteStoredKey removes the file and uninstall takes it too", () => {
   writeStoredKey(paths.keyFile, "sk-x");
   uninstall({ paths });
   assert.equal(existsSync(paths.keyFile), false);
+});
+
+test("proxy setting survives key writes and key deletion", () => {
+  const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
+  writeProxyUrl(keyFile, "  http://127.0.0.1:10808  ");
+  assert.equal(readProxyUrl(keyFile), "http://127.0.0.1:10808");
+  if (process.platform === "win32") {
+    assert.equal(readFileSync(keyFile, "utf8").includes("http://127.0.0.1:10808"), false);
+  }
+
+  writeStoredKey(keyFile, "sk-proxy-test");
+  assert.equal(readProxyUrl(keyFile), "http://127.0.0.1:10808");
+  assert.equal(readStoredKey(keyFile), "sk-proxy-test");
+
+  deleteStoredKey(keyFile);
+  assert.equal(existsSync(keyFile), true);
+  assert.equal(readProxyUrl(keyFile), "http://127.0.0.1:10808");
+
+  writeProxyUrl(keyFile, "");
+  assert.equal(readProxyUrl(keyFile), "");
+  assert.equal(existsSync(keyFile), false);
+});
+
+test("router token is stable, random-looking, and survives key deletion", () => {
+  const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
+  const first = ensureRouterToken(keyFile);
+  assert.match(first, /^[A-Za-z0-9_-]{43}$/);
+  assert.equal(ensureRouterToken(keyFile), first);
+  assert.equal(readRouterToken(keyFile), first);
+  writeStoredKey(keyFile, "sk-token-test");
+  deleteStoredKey(keyFile);
+  assert.equal(readRouterToken(keyFile), first);
+});
+
+test("migrates legacy Windows plaintext keys before serving", () => {
+  if (process.platform !== "win32") return;
+  const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
+  mkdirSync(join(keyFile, ".."), { recursive: true });
+  writeFileSync(keyFile, JSON.stringify({ deepseek_api_key: "legacy-key" }));
+  assert.equal(migrateLegacyStoredKey(keyFile), true);
+  assert.equal(readStoredKey(keyFile), "legacy-key");
+  assert.equal(readFileSync(keyFile, "utf8").includes("legacy-key"), false);
+});
+
+test("state writes migrate legacy Windows plaintext keys immediately", () => {
+  if (process.platform !== "win32") return;
+  const keyFile = join(mkdtempSync(join(tmpdir(), "dscodex-key-")), "dscodex", "config.json");
+  mkdirSync(join(keyFile, ".."), { recursive: true });
+  writeFileSync(keyFile, JSON.stringify({ deepseek_api_key: "legacy-write-key" }));
+
+  writeProxyUrl(keyFile, "http://127.0.0.1:10808");
+  assert.equal(readStoredKey(keyFile), "legacy-write-key");
+  assert.equal(readFileSync(keyFile, "utf8").includes("legacy-write-key"), false);
 });

--- a/test/proxy-config.test.mjs
+++ b/test/proxy-config.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  envProxySupported,
+  proxyEnvFor,
+  proxySource,
+  resolveProxy,
+  usesEnvProxy,
+} from "../src/proxy-config.mjs";
+
+test("resolveProxy precedence: DSCODEX, then generic env, then stored", () => {
+  assert.equal(
+    resolveProxy({ DSCODEX_HTTPS_PROXY: "http://ds:1", HTTPS_PROXY: "http://generic:2" }, "http://stored:3"),
+    "http://ds:1",
+  );
+  assert.equal(
+    resolveProxy({ DSCODEX_HTTP_PROXY: "http://ds:1", HTTP_PROXY: "http://generic:2" }, "http://stored:3"),
+    "http://ds:1",
+  );
+  assert.equal(resolveProxy({ HTTPS_PROXY: "http://generic:2" }, "http://stored:3"), "http://generic:2");
+  assert.equal(resolveProxy({ HTTP_PROXY: "http://generic:2" }, "http://stored:3"), "http://generic:2");
+  assert.equal(resolveProxy({ https_proxy: "http://lower:4" }, "http://stored:3"), "http://lower:4");
+  assert.equal(resolveProxy({ HTTPS_PROXY: "http://upper:5", https_proxy: "http://lower:4" }, "http://stored:3"), "http://lower:4");
+  assert.equal(resolveProxy({}, "  http://stored:3  "), "http://stored:3");
+  assert.equal(resolveProxy({}, ""), "");
+  assert.equal(resolveProxy({ HTTPS_PROXY: "   " }, ""), "");
+});
+
+test("proxySource names the winning source", () => {
+  assert.equal(proxySource({ DSCODEX_HTTPS_PROXY: "x" }, ""), "DSCODEX_*_PROXY env");
+  assert.equal(proxySource({ HTTPS_PROXY: "x" }, ""), "HTTP(S)_PROXY env");
+  assert.equal(proxySource({}, "http://stored"), "stored in config.json");
+  assert.equal(proxySource({}, ""), "");
+});
+
+test("envProxySupported requires Node 24.5+", () => {
+  assert.equal(envProxySupported("v24.2.9"), false);
+  assert.equal(envProxySupported("v24.3.0"), false);
+  assert.equal(envProxySupported("v24.4.9"), false);
+  assert.equal(envProxySupported("v24.5.0"), true);
+  assert.equal(envProxySupported("v24.11.1"), true);
+  assert.equal(envProxySupported("v25.0.0"), true);
+  assert.equal(envProxySupported("v22.15.0"), false);
+  assert.equal(envProxySupported("garbage"), false);
+});
+
+test("proxyEnvFor sets proxy env, loopback NO_PROXY, and the env-proxy flag", () => {
+  const env = proxyEnvFor("http://127.0.0.1:10808", {
+    NO_PROXY: "example.com",
+    NODE_OPTIONS: "--max-old-space-size=512",
+  });
+  assert.equal(env.HTTP_PROXY, "http://127.0.0.1:10808");
+  assert.equal(env.HTTPS_PROXY, "http://127.0.0.1:10808");
+  assert.equal(env.http_proxy, "http://127.0.0.1:10808");
+  assert.equal(env.https_proxy, "http://127.0.0.1:10808");
+  assert.ok(env.NO_PROXY.includes("127.0.0.1"));
+  assert.ok(env.NO_PROXY.includes("localhost"));
+  assert.ok(env.NO_PROXY.includes("example.com"));
+  assert.ok(env.NO_PROXY.includes("api.deepseek.com"));
+  assert.equal(env.no_proxy, env.NO_PROXY);
+  assert.equal(env.NODE_OPTIONS, "--max-old-space-size=512 --use-env-proxy");
+  const existingFlag = proxyEnvFor("http://127.0.0.1:10808", {
+    no_proxy: "API.DEEPSEEK.COM",
+    NODE_OPTIONS: "--use-env-proxy",
+  });
+  assert.equal(existingFlag.NODE_OPTIONS, "--use-env-proxy");
+  assert.equal(existingFlag.NO_PROXY.toLowerCase().split(",").filter((value) => value === "api.deepseek.com").length, 1);
+});
+
+test("usesEnvProxy detects the flag without matching lookalikes", () => {
+  assert.equal(usesEnvProxy({ NODE_OPTIONS: "--use-env-proxy" }), true);
+  assert.equal(usesEnvProxy({ NODE_OPTIONS: "--trace-warnings --use-env-proxy" }), true);
+  assert.equal(usesEnvProxy({ NODE_OPTIONS: "--use-env-proxy-extra" }), false);
+  assert.equal(usesEnvProxy({ NODE_USE_ENV_PROXY: "1" }), true);
+  assert.equal(usesEnvProxy({}), false);
+});
+
+test("validates and redacts credentialed proxy URLs", async () => {
+  const { redactProxyUrl, validateProxyUrl } = await import("../src/proxy-config.mjs");
+  assert.equal(validateProxyUrl(" https://user:pass@example.test:8443 "), "https://user:pass@example.test:8443");
+  assert.match(redactProxyUrl("https://user:pass@example.test:8443"), /redacted/);
+  assert.doesNotMatch(redactProxyUrl("https://user:pass@example.test:8443"), /pass/);
+  assert.doesNotMatch(redactProxyUrl("https://example.test/?token=secret"), /secret/);
+  assert.throws(() => validateProxyUrl("file:///tmp/proxy"), /Invalid proxy URL/);
+});

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -63,7 +63,7 @@ test("routes V4 Flash to native DeepSeek /responses and preserves SSE", async (t
   }));
   const response = await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json", "content-encoding": "zstd" },
+    headers: { "content-type": "application/json", "content-encoding": "zstd", authorization: "Bearer client-token" },
     body: codexBody,
   });
 
@@ -99,7 +99,7 @@ test("preserves explicit High reasoning", async (t) => {
 
   await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", reasoning: { effort: "high", summary: "auto" } }),
   });
   assert.deepEqual(observed.reasoning, { effort: "high" });
@@ -123,7 +123,7 @@ test("maps stale lower Codex efforts onto DeepSeek High", async (t) => {
 
   await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", reasoning: { effort: "medium" } }),
   });
   assert.deepEqual(observed.reasoning, { effort: "high" });
@@ -182,9 +182,35 @@ test("returns an explicit error when V4 Flash is selected without a key", async 
   t.after(async () => { await close(proxy); });
   const response = await fetch(`${proxyUrl}/v1/responses`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash" }),
   });
   assert.equal(response.status, 503);
   assert.match((await response.json()).error.message, /DEEPSEEK_API_KEY/);
+});
+
+test("rejects DeepSeek requests without a client authorization header", async (t) => {
+  let upstreamHits = 0;
+  const upstream = http.createServer(async (request, response) => {
+    upstreamHits += 1;
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("{}");
+  });
+  const upstreamUrl = await listen(upstream);
+  const proxy = createProxyServer({
+    deepSeekKey: "test-key",
+    deepSeekBaseUrl: upstreamUrl,
+    logger: { info() {}, error() {} },
+  });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); await close(upstream); });
+
+  const response = await fetch(`${proxyUrl}/v1/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", input: "hello" }),
+  });
+  assert.equal(response.status, 401);
+  assert.equal(upstreamHits, 0);
+  assert.match((await response.json()).error.message, /authorization header/i);
 });

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -5,6 +5,12 @@ import { once } from "node:events";
 import { gzipSync, zstdCompressSync } from "node:zlib";
 import { createProxyServer } from "../src/proxy.mjs";
 
+const ROUTER_TOKEN = "A".repeat(43);
+
+function route(proxyUrl, path = "/v1/responses") {
+  return `${proxyUrl}/${ROUTER_TOKEN}${path}`;
+}
+
 async function listen(server) {
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
@@ -47,6 +53,7 @@ test("routes V4 Flash to native DeepSeek /responses and preserves SSE", async (t
     deepSeekBaseUrl: upstreamUrl,
     chatGptBaseUrl: upstreamUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(upstream); });
@@ -61,7 +68,7 @@ test("routes V4 Flash to native DeepSeek /responses and preserves SSE", async (t
       { id: "call_1", type: "function_call_output", call_id: "call_7", output: "done" },
     ],
   }));
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", "content-encoding": "zstd", authorization: "Bearer client-token" },
     body: codexBody,
@@ -93,11 +100,12 @@ test("preserves explicit High reasoning", async (t) => {
     deepSeekKey: "test-key",
     deepSeekBaseUrl: upstreamUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(upstream); });
 
-  await fetch(`${proxyUrl}/v1/responses`, {
+  await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", reasoning: { effort: "high", summary: "auto" } }),
@@ -117,11 +125,12 @@ test("maps stale lower Codex efforts onto DeepSeek High", async (t) => {
     deepSeekKey: "test-key",
     deepSeekBaseUrl: upstreamUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(upstream); });
 
-  await fetch(`${proxyUrl}/v1/responses`, {
+  await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", reasoning: { effort: "medium" } }),
@@ -145,12 +154,13 @@ test("forwards native GPT models to ChatGPT Codex with OAuth headers", async (t)
   const proxy = createProxyServer({
     chatGptBaseUrl: `${upstreamUrl}/backend-api/codex`,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(upstream); });
 
   const original = { model: "gpt-5.6-sol", reasoning: { effort: "high" }, input: "hello" };
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -167,7 +177,7 @@ test("forwards native GPT models to ChatGPT Codex with OAuth headers", async (t)
 });
 
 test("keeps pooled loopback connections alive past the Codex client idle timeout", async (t) => {
-  const proxy = createProxyServer({ logger: { info() {}, error() {} } });
+  const proxy = createProxyServer({ logger: { info() {}, error() {} }, routerToken: ROUTER_TOKEN });
   await listen(proxy);
   t.after(async () => { await close(proxy); });
   // The Codex HTTP client pools connections with a ~90s idle timeout; a shorter
@@ -176,11 +186,65 @@ test("keeps pooled loopback connections alive past the Codex client idle timeout
   assert.ok(proxy.headersTimeout > proxy.keepAliveTimeout);
 });
 
-test("returns an explicit error when V4 Flash is selected without a key", async (t) => {
-  const proxy = createProxyServer({ deepSeekKey: "", logger: { info() {}, error() {} } });
+test("requires a router token and rejects oversized compressed bodies", async (t) => {
+  assert.throws(() => createProxyServer({ logger: { info() {}, error() {} } }), /routerToken is required/);
+  const proxy = createProxyServer({
+    deepSeekKey: "test-key",
+    routerToken: ROUTER_TOKEN,
+    maxRequestBytes: 256,
+    maxDecodedBytes: 32,
+    logger: { info() {}, error() {} },
+  });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); });
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+
+  const tooLarge = await fetch(route(proxyUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "gpt-5.6-sol", input: "x".repeat(1_000) }),
+  });
+  assert.equal(tooLarge.status, 413);
+
+  const compressed = gzipSync(JSON.stringify({ model: "gpt-5.6-sol", input: "x".repeat(1_000) }));
+  const decompressionBomb = await fetch(route(proxyUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json", "content-encoding": "gzip" },
+    body: compressed,
+  });
+  assert.equal(decompressionBomb.status, 413);
+});
+
+test("shutdown requires the per-instance token", async (t) => {
+  const shutdownToken = "B".repeat(43);
+  let shutdownCalls = 0;
+  const proxy = createProxyServer({
+    routerToken: ROUTER_TOKEN,
+    shutdownToken,
+    onShutdown: () => { shutdownCalls += 1; },
+    logger: { info() {}, error() {} },
+  });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); });
+
+  const rejected = await fetch(route(proxyUrl, "/_dscodex/shutdown"), {
+    method: "POST",
+    headers: { "x-dscodex-shutdown-token": "C".repeat(43) },
+  });
+  assert.equal(rejected.status, 401);
+  const accepted = await fetch(route(proxyUrl, "/_dscodex/shutdown"), {
+    method: "POST",
+    headers: { "x-dscodex-shutdown-token": shutdownToken },
+  });
+  assert.equal(accepted.status, 202);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(shutdownCalls, 1);
+});
+
+test("returns an explicit error when V4 Flash is selected without a key", async (t) => {
+  const proxy = createProxyServer({ deepSeekKey: "", logger: { info() {}, error() {} }, routerToken: ROUTER_TOKEN });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); });
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer client-token" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash" }),
@@ -189,7 +253,7 @@ test("returns an explicit error when V4 Flash is selected without a key", async 
   assert.match((await response.json()).error.message, /DEEPSEEK_API_KEY/);
 });
 
-test("rejects DeepSeek requests without a client authorization header", async (t) => {
+test("rejects requests without the router token, while OAuth remains optional", async (t) => {
   let upstreamHits = 0;
   const upstream = http.createServer(async (request, response) => {
     upstreamHits += 1;
@@ -201,6 +265,7 @@ test("rejects DeepSeek requests without a client authorization header", async (t
     deepSeekKey: "test-key",
     deepSeekBaseUrl: upstreamUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(upstream); });
@@ -210,7 +275,15 @@ test("rejects DeepSeek requests without a client authorization header", async (t
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", input: "hello" }),
   });
-  assert.equal(response.status, 401);
+  assert.equal(response.status, 404);
   assert.equal(upstreamHits, 0);
-  assert.match((await response.json()).error.message, /authorization header/i);
+  assert.match((await response.json()).error.message, /not found/i);
+
+  const authorized = await fetch(route(proxyUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", input: "hello" }),
+  });
+  assert.equal(authorized.status, 200);
+  assert.equal(upstreamHits, 1);
 });

--- a/test/vision.test.mjs
+++ b/test/vision.test.mjs
@@ -4,6 +4,12 @@ import test from "node:test";
 import { once } from "node:events";
 import { createProxyServer } from "../src/proxy.mjs";
 
+const ROUTER_TOKEN = "A".repeat(43);
+
+function route(proxyUrl, path = "/v1/responses") {
+  return `${proxyUrl}/${ROUTER_TOKEN}${path}`;
+}
+
 const IMAGE_A = `data:image/png;base64,${"A".repeat(64)}`;
 const IMAGE_B = `data:image/png;base64,${"B".repeat(64)}`;
 
@@ -115,12 +121,13 @@ test("rewrites DeepSeek-bound images into GPT descriptions, concurrent and cache
     deepSeekBaseUrl: deepSeekUrl,
     chatGptBaseUrl: chatGptUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(chatGpt); await close(deepSeek); });
 
   const startedAt = Date.now();
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer oauth-token" },
     body: JSON.stringify(deepSeekRequest([IMAGE_A, IMAGE_B, IMAGE_A])),
@@ -144,7 +151,7 @@ test("rewrites DeepSeek-bound images into GPT descriptions, concurrent and cache
   assert.ok(texts.includes("what do you see"));
 
   // A later request with the same image hits the cache, not the vision API.
-  const cached = await fetch(`${proxyUrl}/v1/responses`, {
+  const cached = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer oauth-token" },
     body: JSON.stringify(deepSeekRequest([IMAGE_A])),
@@ -162,6 +169,7 @@ test("leaves native GPT passthrough bodies untouched", async (t) => {
     deepSeekKey: "test-key",
     chatGptBaseUrl: chatGptUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(chatGpt); });
@@ -170,7 +178,7 @@ test("leaves native GPT passthrough bodies untouched", async (t) => {
     model: "gpt-5.6-sol",
     input: [{ type: "message", role: "user", content: [{ type: "input_image", image_url: IMAGE_A }] }],
   };
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer oauth-token" },
     body: JSON.stringify(original),
@@ -192,11 +200,12 @@ test("marks images with a placeholder when the vision call fails", async (t) => 
     deepSeekBaseUrl: deepSeekUrl,
     chatGptBaseUrl: chatGptUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(chatGpt); await close(deepSeek); });
 
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer oauth-token" },
     body: JSON.stringify(deepSeekRequest([IMAGE_A])),
@@ -206,7 +215,7 @@ test("marks images with a placeholder when the vision call fails", async (t) => 
   assert.ok(collectText(deepSeekReceived[0]).some((text) => text.includes("could not analyze")));
 });
 
-test("rejects DeepSeek-bound image requests without credentials", async (t) => {
+test("passes DeepSeek-bound images through when OAuth credentials are absent", async (t) => {
   const chatGptCalls = [];
   const deepSeekReceived = [];
   const chatGpt = createFakeChatGpt(chatGptCalls);
@@ -218,16 +227,18 @@ test("rejects DeepSeek-bound image requests without credentials", async (t) => {
     deepSeekBaseUrl: deepSeekUrl,
     chatGptBaseUrl: chatGptUrl,
     logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
   });
   const proxyUrl = await listen(proxy);
   t.after(async () => { await close(proxy); await close(chatGpt); await close(deepSeek); });
 
-  const response = await fetch(`${proxyUrl}/v1/responses`, {
+  const response = await fetch(route(proxyUrl), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(deepSeekRequest([IMAGE_A])),
   });
-  assert.equal(response.status, 401);
+  assert.equal(response.status, 200);
   assert.equal(chatGptCalls.length, 0);
-  assert.equal(deepSeekReceived.length, 0);
+  assert.equal(deepSeekReceived.length, 1);
+  assert.equal(countImages(deepSeekReceived[0]), 1);
 });

--- a/test/vision.test.mjs
+++ b/test/vision.test.mjs
@@ -206,7 +206,7 @@ test("marks images with a placeholder when the vision call fails", async (t) => 
   assert.ok(collectText(deepSeekReceived[0]).some((text) => text.includes("could not analyze")));
 });
 
-test("skips the vision rewrite without ChatGPT OAuth headers", async (t) => {
+test("rejects DeepSeek-bound image requests without credentials", async (t) => {
   const chatGptCalls = [];
   const deepSeekReceived = [];
   const chatGpt = createFakeChatGpt(chatGptCalls);
@@ -227,7 +227,7 @@ test("skips the vision rewrite without ChatGPT OAuth headers", async (t) => {
     headers: { "content-type": "application/json" },
     body: JSON.stringify(deepSeekRequest([IMAGE_A])),
   });
-  assert.equal(response.status, 200);
+  assert.equal(response.status, 401);
   assert.equal(chatGptCalls.length, 0);
-  assert.equal(countImages(deepSeekReceived[0]), 1);
+  assert.equal(deepSeekReceived.length, 0);
 });


### PR DESCRIPTION
## 恢复说明

此前的 PR #3 因误操作被关闭，无法恢复，因此重新提交本 PR。

本次提交内容与原 PR 基本一致，`security-hardening` 分支也已经同步到我 fork 的 `main` 分支。

## 主要改动

- 为本地回环路由增加认证令牌，阻止未授权请求。
- 强化关闭握手、PID 状态管理和替代实例保护。
- 限制压缩请求体和解压后的请求体大小。
- Windows 使用 DPAPI 加密 DeepSeek API Key 和带凭据的代理地址。
- 自动迁移旧版本的 Windows 明文 Key。
- 增加代理解析和 Node.js `--use-env-proxy` 支持。
- 保证回环地址和 `api.deepseek.com` 不经过代理。
- 修复自启动脚本的路径转义和中文用户名目录兼容性。
- 自启动只在进程崩溃后重启，正常停止后不会自动拉起。
- 最低 Node.js 版本调整为 24.5。

## 验证结果

- `npm test`：60 个测试通过，1 个 Windows 平台测试按预期跳过。
- `git diff --check`：通过。