### PR TITLE
fix: make DeepSeek Responses tool-loop replay compatible

### DIFF
--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -118,6 +118,78 @@ function convertInputItem(item, compactionSecret) {
   return converted;
 }
 
+// DeepSeek's Responses API requires each function_call_output to directly
+// follow its function_call. Codex can interleave other items (e.g. PostToolUse
+// hook context inserted as a developer message) between the two, which makes
+// DeepSeek reject the request with "No tool output found for tool call ...".
+// Re-pair every output with its call and flush interleaved items right after
+// the pair so ordering stays valid while preserving overall item order.
+function normalizeToolOutputOrder(items) {
+  if (!Array.isArray(items)) return items;
+  const result = [];
+  const deferred = [];
+  const pendingCalls = [];
+  let turnReasoning = null;
+  let emittedCallsInTurn = 0;
+  for (const item of items) {
+    if (!item || typeof item !== "object") {
+      result.push(item);
+      continue;
+    }
+    if (item.type === "reasoning") {
+      turnReasoning = item;
+      emittedCallsInTurn = 0;
+      if (pendingCalls.length > 0) {
+        deferred.push(item);
+      } else {
+        result.push(item);
+      }
+      continue;
+    }
+    if (item.type === "message" && (item.role === "assistant" || item.role === "user")) {
+      emittedCallsInTurn = 0;
+      if (pendingCalls.length > 0) {
+        deferred.push(item);
+      } else {
+        result.push(item);
+      }
+      continue;
+    }
+    if (item.type === "function_call") {
+      pendingCalls.push(item);
+      continue;
+    }
+    if (item.type === "function_call_output") {
+      const callId = item.call_id ?? item.id;
+      const index = pendingCalls.findIndex((call) => (call.call_id ?? call.id) === callId);
+      if (index !== -1) {
+        const call = pendingCalls.splice(index, 1)[0];
+        // DeepSeek's Responses API rejects an assistant turn that contains more
+        // than one function_call unless each extra call has its own
+        // reasoning_text (it reports a misleading "reasoning_text must be
+        // passed back" otherwise). Duplicate the turn's reasoning for every
+        // additional parallel call so multi-call turns replay cleanly.
+        if (turnReasoning && emittedCallsInTurn > 0) {
+          result.push({ ...turnReasoning, content: turnReasoning.content?.map((part) => ({ ...part })) });
+        }
+        result.push(call);
+        emittedCallsInTurn += 1;
+      }
+      result.push(item);
+      result.push(...deferred);
+      deferred.length = 0;
+      continue;
+    }
+    if (pendingCalls.length > 0) {
+      deferred.push(item);
+    } else {
+      result.push(item);
+    }
+  }
+  result.push(...pendingCalls, ...deferred);
+  return result;
+}
+
 export function buildDeepSeekBody(input, { compactionSecret = "" } = {}) {
   const body = structuredClone(input);
   const requestedEffort = body.reasoning?.effort;
@@ -136,9 +208,11 @@ export function buildDeepSeekBody(input, { compactionSecret = "" } = {}) {
   delete body.metadata;
   delete body.service_tier;
   if (Array.isArray(body.input)) {
-    body.input = body.input
-      .map((item) => convertInputItem(item, compactionSecret))
-      .filter((item) => item != null);
+    body.input = normalizeToolOutputOrder(
+      body.input
+        .map((item) => convertInputItem(item, compactionSecret))
+        .filter((item) => item != null),
+    );
   }
   return body;
 }


### PR DESCRIPTION
## Summary

Fixes #9 (both failure modes reported there). DeepSeek's Responses API is stricter than OpenAI's about replaying tool-call turns, and Codex can produce shapes DeepSeek rejects:

1. **Interleaved items between a `function_call` and its `function_call_output`** — Codex inserts PostToolUse hook context as a `role: developer` message, which can land between a call and its output. DeepSeek then rejects with `No tool output found for tool call …` (OpenAI tolerates the interleaving, so the same conversation works with GPT models).
2. **More than one parallel `function_call` in a turn with a single shared `reasoning_text`** — DeepSeek rejects with a misleading `The reasoning_text in the thinking mode must be passed back to the API.` even though the reasoning is present. The model itself can emit two parallel calls in one response, but replaying that turn always 400s, wedging the session.

## Changes

- `src/proxy.mjs`: add `normalizeToolOutputOrder()`, applied when building the DeepSeek request body:
  - re-pair every `function_call_output` with its matching `function_call`, flushing interleaved items (e.g. hook-context developer messages) right after the pair;
  - duplicate the turn's `reasoning_text` for every extra parallel `function_call` so multi-call turns replay cleanly.
- Rebased on current upstream main (coexists with the compaction-item handling).

## Verification

Minimal reproductions against `api.deepseek.com/responses` (through DSCodex):

| input shape | before | after |
|---|---|---|
| `[…, function_call, developer-message, function_call_output, …]` | 400 `No tool output found for tool call …` | 200 |
| `[reasoning, function_call, function_call, output, output]` | 400 `reasoning_text must be passed back` | 200 |
| single-call turns (normal loop) | 200 | 200 (no regression) |
