### PR TITLE
fix: make DeepSeek Responses tool-loop replay compatible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,14 @@ The non-negotiable details:
     (GPT-sealed after a provider switch, or a rotated token) must be dropped, never forwarded raw
     to DeepSeek. Never route compaction through GPT or store the summary as plaintext in the
     rollout file.
+13. DeepSeek's Responses API is stricter than OpenAI's about replaying tool-call turns, and a
+    rejected replay wedges the session permanently because the bad shape stays in the history.
+    Every tool output must directly follow its call — Codex inserts PostToolUse hook context as a
+    `developer` message that can land inside the pair — so the router re-pairs them for
+    `function_call`, `custom_tool_call`, and `local_shell_call`; the repair must preserve the
+    relative order of every other item and must leave a call whose output is missing where it is.
+    A turn must never replay more than one tool call behind a single `reasoning` item (DeepSeek
+    reports a misleading "reasoning_text must be passed back"), so the catalog entry sets
+    `supports_parallel_tool_calls = false` and the router forces `parallel_tool_calls: false`;
+    duplicating the turn's reasoning for extra calls is replay repair for already-wedged sessions
+    only, and must never copy reasoning across a turn boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,12 @@ The non-negotiable details:
     `developer` message that can land inside the pair — so the router re-pairs them for
     `function_call`, `custom_tool_call`, and `local_shell_call`; the repair must preserve the
     relative order of every other item and must leave a call whose output is missing where it is.
-    A turn must never replay more than one tool call behind a single `reasoning` item (DeepSeek
-    reports a misleading "reasoning_text must be passed back"), so the catalog entry sets
-    `supports_parallel_tool_calls = false` and the router forces `parallel_tool_calls: false`;
-    duplicating the turn's reasoning for extra calls is replay repair for already-wedged sessions
-    only, and must never copy reasoning across a turn boundary.
+    Pair on `call_id`, never on `id`: Codex sends both, but `id` is a local UUID and only `call_id`
+    carries the `call_…` value the API matches on. A turn must never replay more than one tool call
+    behind a single `reasoning` item (DeepSeek reports a misleading "reasoning_text must be passed
+    back"), so the catalog entry sets `supports_parallel_tool_calls = false` and the router forces
+    `parallel_tool_calls: false`; duplicating the turn's reasoning for extra calls is replay repair
+    for already-wedged sessions only, and must never copy reasoning across a turn boundary. A turn
+    runs from its `reasoning` item through its calls and includes the assistant preamble message
+    Codex emits in between — real rollouts show `reasoning` → `message(assistant)` → call, call —
+    while a tool output ends it.

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -57,7 +57,10 @@ export function buildDeepSeekCatalogEntry(template) {
   // rewrites those images into GPT-generated descriptions before DeepSeek sees them.
   entry.input_modalities = ["text", "image"];
   entry.supports_image_detail_original = false;
-  entry.supports_parallel_tool_calls = true;
+  // DeepSeek's Responses API rejects a turn that replays more than one tool call
+  // ("The reasoning_text in the thinking mode must be passed back to the API."),
+  // which wedges every later request in the session. Never ask for parallel calls.
+  entry.supports_parallel_tool_calls = false;
   entry.supports_search_tool = true;
   entry.tool_mode = null;
   entry.multi_agent_version = "v2";

--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -118,6 +118,76 @@ function convertInputItem(item, compactionSecret) {
   return converted;
 }
 
+// Codex replays a tool call as a call item plus a matching output item. DeepSeek's
+// Responses API requires the output to directly follow its call; OpenAI's tolerates
+// items in between, and Codex inserts PostToolUse hook context as a developer
+// message that can land inside the pair. DeepSeek then rejects the whole request
+// with "No tool output found for tool call ...", and because the developer message
+// stays in the session history every later request fails the same way.
+const CALL_OUTPUT_TYPES = new Map([
+  ["function_call", "function_call_output"],
+  ["custom_tool_call", "custom_tool_call_output"],
+  ["local_shell_call", "local_shell_call_output"],
+]);
+
+// DeepSeek also rejects a replayed assistant turn that carries more than one tool
+// call behind a single reasoning item — reporting a misleading "The reasoning_text
+// in the thinking mode must be passed back to the API." — even though the model
+// emits such turns itself. Give every extra call in the turn its own copy of the
+// turn's reasoning. Only an uninterrupted run of reasoning and call items counts as
+// one turn, so a turn that carries no reasoning of its own never inherits an
+// earlier turn's.
+function reasoningForExtraCalls(items) {
+  const clones = new Map();
+  let turnReasoning = null;
+  let callsInTurn = 0;
+  items.forEach((item, index) => {
+    const type = item && typeof item === "object" ? item.type : undefined;
+    if (type === "reasoning") {
+      turnReasoning = item;
+      callsInTurn = 0;
+      return;
+    }
+    if (CALL_OUTPUT_TYPES.has(type)) {
+      if (turnReasoning && callsInTurn > 0) clones.set(index, turnReasoning);
+      callsInTurn += 1;
+      return;
+    }
+    turnReasoning = null;
+    callsInTurn = 0;
+  });
+  return clones;
+}
+
+// Pull each tool output up to sit directly after its call, leaving every other item
+// in its original relative position. A call whose output is missing stays where it
+// is instead of dragging the rest of the conversation out of order.
+function normalizeToolCallReplay(items) {
+  if (!Array.isArray(items)) return items;
+  const clones = reasoningForExtraCalls(items);
+  const consumed = new Set();
+  const result = [];
+  for (let index = 0; index < items.length; index += 1) {
+    if (consumed.has(index)) continue;
+    const item = items[index];
+    const reasoning = clones.get(index);
+    if (reasoning) result.push(structuredClone(reasoning));
+    result.push(item);
+    const outputType = item && typeof item === "object" ? CALL_OUTPUT_TYPES.get(item.type) : undefined;
+    if (!outputType || item.call_id == null) continue;
+    for (let next = index + 1; next < items.length; next += 1) {
+      if (consumed.has(next)) continue;
+      const candidate = items[next];
+      if (candidate?.type === outputType && candidate.call_id === item.call_id) {
+        result.push(candidate);
+        consumed.add(next);
+        break;
+      }
+    }
+  }
+  return result;
+}
+
 export function buildDeepSeekBody(input, { compactionSecret = "" } = {}) {
   const body = structuredClone(input);
   const requestedEffort = body.reasoning?.effort;
@@ -135,10 +205,15 @@ export function buildDeepSeekBody(input, { compactionSecret = "" } = {}) {
   delete body.background;
   delete body.metadata;
   delete body.service_tier;
+  // DeepSeek emits parallel tool calls but cannot accept the resulting turn back,
+  // so keep the shape out of the history in the first place.
+  body.parallel_tool_calls = false;
   if (Array.isArray(body.input)) {
-    body.input = body.input
-      .map((item) => convertInputItem(item, compactionSecret))
-      .filter((item) => item != null);
+    body.input = normalizeToolCallReplay(
+      body.input
+        .map((item) => convertInputItem(item, compactionSecret))
+        .filter((item) => item != null),
+    );
   }
   return body;
 }

--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -134,9 +134,10 @@ const CALL_OUTPUT_TYPES = new Map([
 // call behind a single reasoning item — reporting a misleading "The reasoning_text
 // in the thinking mode must be passed back to the API." — even though the model
 // emits such turns itself. Give every extra call in the turn its own copy of the
-// turn's reasoning. Only an uninterrupted run of reasoning and call items counts as
-// one turn, so a turn that carries no reasoning of its own never inherits an
-// earlier turn's.
+// turn's reasoning. A turn is a run of reasoning, assistant messages (Codex emits a
+// preamble between the reasoning and the calls), and call items; anything else —
+// notably a tool output — ends it, so a turn that carries no reasoning of its own
+// never inherits an earlier turn's.
 function reasoningForExtraCalls(items) {
   const clones = new Map();
   let turnReasoning = null;
@@ -148,6 +149,7 @@ function reasoningForExtraCalls(items) {
       callsInTurn = 0;
       return;
     }
+    if (type === "message" && item.role === "assistant") return;
     if (CALL_OUTPUT_TYPES.has(type)) {
       if (turnReasoning && callsInTurn > 0) clones.set(index, turnReasoning);
       callsInTurn += 1;

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -3,7 +3,7 @@ import http from "node:http";
 import test from "node:test";
 import { once } from "node:events";
 import { gzipSync, zstdCompressSync } from "node:zlib";
-import { createProxyServer } from "../src/proxy.mjs";
+import { buildDeepSeekBody, createProxyServer } from "../src/proxy.mjs";
 
 const ROUTER_TOKEN = "A".repeat(43);
 
@@ -410,4 +410,103 @@ test("rejects requests without the router token, while OAuth remains optional", 
   });
   assert.equal(authorized.status, 200);
   assert.equal(upstreamHits, 1);
+});
+
+const shape = (items) =>
+  items.map((item) =>
+    item.type === "message" ? `${item.role}:${item.content[0].text}`
+      : item.type === "reasoning" ? `reasoning:${item.content[0].text}`
+        : `${item.type}:${item.call_id}`);
+
+const say = (role, text) => ({ type: "message", role, content: [{ type: "input_text", text }] });
+const think = (text) => ({ type: "reasoning", content: [{ type: "reasoning_text", text }] });
+
+test("re-pairs a tool output with its call when hook context is interleaved", () => {
+  const body = buildDeepSeekBody({
+    model: "deepseek/deepseek-v4-flash",
+    input: [
+      say("user", "u1"),
+      think("r1"),
+      { type: "function_call", call_id: "c1", name: "shell", arguments: "{}" },
+      say("developer", "GitNexus index is stale"),
+      { type: "function_call_output", call_id: "c1", output: "ok" },
+      { type: "custom_tool_call", call_id: "p1", name: "apply_patch", input: "*** Begin Patch" },
+      say("developer", "hook again"),
+      { type: "custom_tool_call_output", call_id: "p1", output: "done" },
+    ],
+  });
+
+  assert.deepEqual(shape(body.input), [
+    "user:u1",
+    "reasoning:r1",
+    "function_call:c1",
+    "function_call_output:c1",
+    "developer:GitNexus index is stale",
+    "custom_tool_call:p1",
+    "custom_tool_call_output:p1",
+    "developer:hook again",
+  ]);
+});
+
+test("leaves conversation order alone when a tool call has no output", () => {
+  const input = [
+    say("user", "u1"),
+    think("r1"),
+    { type: "function_call", call_id: "orphan", name: "shell", arguments: "{}" },
+    say("user", "never mind, do this instead"),
+    think("r2"),
+    { type: "function_call", call_id: "c2", name: "shell", arguments: "{}" },
+    { type: "function_call_output", call_id: "c2", output: "ok" },
+    say("user", "u3"),
+  ];
+
+  const body = buildDeepSeekBody({ model: "deepseek/deepseek-v4-flash", input });
+  assert.deepEqual(shape(body.input), shape(input));
+});
+
+test("gives each parallel tool call its own reasoning without leaking it into later turns", () => {
+  const parallel = buildDeepSeekBody({
+    model: "deepseek/deepseek-v4-flash",
+    input: [
+      say("user", "u1"),
+      think("r1"),
+      { type: "function_call", call_id: "c1", name: "shell", arguments: "{}" },
+      { type: "function_call", call_id: "c2", name: "shell", arguments: "{}" },
+      { type: "function_call_output", call_id: "c1", output: "a" },
+      { type: "function_call_output", call_id: "c2", output: "b" },
+    ],
+  });
+  assert.deepEqual(shape(parallel.input), [
+    "user:u1",
+    "reasoning:r1",
+    "function_call:c1",
+    "function_call_output:c1",
+    "reasoning:r1",
+    "function_call:c2",
+    "function_call_output:c2",
+  ]);
+  assert.notEqual(parallel.input[1], parallel.input[4]);
+
+  // A second turn that carries no reasoning of its own must not inherit the first turn's.
+  const sequential = buildDeepSeekBody({
+    model: "deepseek/deepseek-v4-flash",
+    input: [
+      say("user", "u1"),
+      think("r1"),
+      { type: "function_call", call_id: "c1", name: "shell", arguments: "{}" },
+      { type: "function_call_output", call_id: "c1", output: "a" },
+      { type: "function_call", call_id: "c2", name: "shell", arguments: "{}" },
+      { type: "function_call_output", call_id: "c2", output: "b" },
+    ],
+  });
+  assert.equal(sequential.input.filter((item) => item.type === "reasoning").length, 1);
+});
+
+test("never asks DeepSeek for parallel tool calls", () => {
+  const body = buildDeepSeekBody({
+    model: "deepseek/deepseek-v4-flash",
+    parallel_tool_calls: true,
+    input: [say("user", "u1")],
+  });
+  assert.equal(body.parallel_tool_calls, false);
 });

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -487,6 +487,31 @@ test("gives each parallel tool call its own reasoning without leaking it into la
   ]);
   assert.notEqual(parallel.input[1], parallel.input[4]);
 
+  // Codex emits an assistant preamble between the reasoning and the calls; that
+  // message is part of the same turn, so the extra call still needs a copy.
+  const withPreamble = buildDeepSeekBody({
+    model: "deepseek/deepseek-v4-flash",
+    input: [
+      say("user", "u1"),
+      think("r1"),
+      say("assistant", "Checking two things"),
+      { type: "function_call", call_id: "c1", name: "shell", arguments: "{}" },
+      { type: "function_call", call_id: "c2", name: "shell", arguments: "{}" },
+      { type: "function_call_output", call_id: "c1", output: "a" },
+      { type: "function_call_output", call_id: "c2", output: "b" },
+    ],
+  });
+  assert.deepEqual(shape(withPreamble.input), [
+    "user:u1",
+    "reasoning:r1",
+    "assistant:Checking two things",
+    "function_call:c1",
+    "function_call_output:c1",
+    "reasoning:r1",
+    "function_call:c2",
+    "function_call_output:c2",
+  ]);
+
   // A second turn that carries no reasoning of its own must not inherit the first turn's.
   const sequential = buildDeepSeekBody({
     model: "deepseek/deepseek-v4-flash",


### PR DESCRIPTION
## Summary

Fixes #9 (both failure modes). Supersedes #10 — same diagnosis, different normalization. All credit for finding this, and for the reproduction table, goes to @layneyu.

DeepSeek's Responses API is stricter than OpenAI's about replaying tool-call turns, and a rejected replay wedges the session for good: the offending shape stays in the history, so every later request fails identically.

1. **Hook context inside a call/output pair** — Codex inserts PostToolUse hook context as a `developer` message that can land between a `function_call` and its `function_call_output`. DeepSeek requires the output to directly follow its call and answers `No tool output found for tool call …`.
2. **More than one tool call behind a single `reasoning` item** — rejected with a misleading `The reasoning_text in the thinking mode must be passed back to the API.`, even though DeepSeek emits such turns itself.

## Changes

**`src/proxy.mjs`** — `normalizeToolCallReplay()`, applied when building the DeepSeek body:

- Pulls each output up to sit directly after its call, rather than deferring the interleaved items. Every other item keeps its original relative position, and a call whose output is missing stays where it is, so one unpaired call cannot drag the rest of the conversation out of order.
- Covers `function_call`, `custom_tool_call`, and `local_shell_call`. The catalog sets `apply_patch_tool_type = "freeform"`, so apply_patch takes the custom-tool path and hits the same rejection.
- Pairs on `call_id`. Codex sends both `id` and `call_id`, but `id` is a local UUID; only `call_id` holds the `call_…` value the API matches on.
- Forces `parallel_tool_calls: false` on DeepSeek-bound bodies.

**`src/catalog.mjs`** — the V4 Flash entry no longer advertises `supports_parallel_tool_calls`. DeepSeek cannot accept back a multi-call turn it emitted itself, so the durable fix is to stop producing the shape.

Sessions already wedged by a multi-call turn are still repaired: the turn's reasoning is duplicated for each extra call. A turn runs from its `reasoning` item through its calls and includes the assistant preamble Codex emits in between; a tool output ends it, which is what stops reasoning from leaking into a later turn that carries none of its own.

**`AGENTS.md`** — records the replay constraints as invariant 13.

## Verification

`npm test` — 76/76 pass. Four new unit tests over `buildDeepSeekBody` cover the repro cases from #9, the assistant-preamble turn shape, and regressions for orphan-call reordering and cross-turn reasoning copies.

| input shape | before | after |
|---|---|---|
| `fc, developer-message, fco` | 400 | `fc, fco, developer-message` |
| `custom_tool_call, developer-message, custom_tool_call_output` | unchanged (still 400) | pair restored |
| `reasoning, fc1, fc2, fco1, fco2` | 400 | `reasoning, fc1, fco1, reasoning, fc2, fco2` |
| `reasoning, assistant preamble, fc1, fc2, …` | 400 | reasoning copied for `fc2` |
| unpaired `fc` mid-conversation | — | order fully preserved |
| turn with no reasoning after a turn with one | — | no reasoning copied across the boundary |

### Validated against real Codex rollouts

42 sessions, 8154 `response_item`s, 2298 tool calls, replayed through `buildDeepSeekBody`:

- `call_id` present on 2298/2298 calls; 0 outputs missing one.
- `custom_tool_call` / `custom_tool_call_output`: 1322 each, more than `function_call` (947) — that path matters in practice.
- 56 parallel-call turns, confirming failure mode 2 is what sessions actually hit. Of those, 36 use the `reasoning → assistant preamble → call, call` shape; an earlier revision of this branch treated the preamble as a turn boundary and left them unrepaired (fixed in 3e7c53d, coverage 17 → 55).
- 0 unpaired calls, so the order-preservation property is defensive rather than a fix for an observed break.
- No developer message landed inside a pair in this corpus (no PostToolUse hook configured on that machine), so failure mode 1 rests on the trace in #9; 191 developer-role messages do appear in the rollouts, so the item type itself is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
