### PR TITLE
fix: keep a client reset on the 426 upgrade probe from killing the router

### DIFF
--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -587,6 +587,10 @@ export function createProxyServer({
   server.keepAliveTimeout = 120_000;
   server.headersTimeout = 125_000;
   server.on("upgrade", (_request, socket) => {
+    // Handling `upgrade` detaches the socket from the server's own error
+    // handling, so an ECONNRESET here raised an unhandled 'error' event and
+    // killed the whole router — Codex then sat in "reconnecting" forever.
+    socket.on("error", () => {});
     socket.end("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n");
   });
   return server;

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import http from "node:http";
+import net from "node:net";
 import test from "node:test";
 import { once } from "node:events";
 import { gzipSync, zstdCompressSync } from "node:zlib";
@@ -545,4 +546,32 @@ test("never asks DeepSeek for parallel tool calls", () => {
     input: [say("user", "u1")],
   });
   assert.equal(body.parallel_tool_calls, false);
+});
+
+// Regression: the `upgrade` handler used to leave its detached socket without an
+// error listener, so a client reset raised an unhandled 'error' event and took
+// the whole router down — Codex then sat in "reconnecting" until a manual start.
+test("survives a client reset on an upgrade attempt", async (t) => {
+  const proxy = createProxyServer({
+    deepSeekKey: "test-key",
+    logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
+  });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); });
+  const { port } = proxy.address();
+
+  const socket = net.connect(port, "127.0.0.1");
+  await once(socket, "connect");
+  socket.write(
+    "GET /v1/models HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+    + "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+  );
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  socket.resetAndDestroy();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  // Still serving: an unhandled 'error' event would have killed this process.
+  const response = await fetch(route(proxyUrl, "/v1/models"));
+  assert.equal(response.status, 200);
 });


### PR DESCRIPTION
## Symptom

The router dies on its own, and Codex Desktop then sits in "reconnecting" forever. Nothing restarts it: `openai_base_url` still points at `127.0.0.1:<port>`, but no process is listening there, so every request fails to connect.

From `~/.codex/dscodex/server.log` — a clean start, then the process throws and exits:

```
2026-08-12T19:18:28.766Z DSCodex 1.0.0 listening at http://127.0.0.1:10110/v1
2026-08-12T19:18:28.767Z DeepSeek key: configured
node:events:486
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -4077,
  code: 'ECONNRESET',
  syscall: 'read'
}
```

## Cause

`createProxyServer` handles the `upgrade` event itself to answer websocket probes with 426:

```js
server.on("upgrade", (_request, socket) => {
  socket.end("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n");
});
```

Once a listener handles `upgrade`, Node hands the socket over and stops managing it — it is no longer covered by the server's own socket error handling, and errors on it never reach `clientError`. This handler attaches no `error` listener, so if the client resets that connection instead of closing it cleanly, the socket emits `error` with nothing listening. Node turns an unhandled `error` event into a throw, and the whole router exits.

What makes this more than a rare race: per `AGENTS.md`, the catalog declares `prefer_websockets = false`, so Codex probes for websockets and the router answers 426 as a matter of course. The upgrade path runs routinely, which means a routine probe can take the router down.

This is not platform-specific — an unhandled `error` event ends the process on any OS. It was observed on Windows with Node v24.14.1.

## Fix

One line: attach a no-op error listener before replying. A reset on a probe socket is expected and uninteresting, so it is swallowed rather than logged — logging it would add noise on a path that runs constantly.

```js
server.on("upgrade", (_request, socket) => {
  socket.on("error", () => {});
  socket.end("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n");
});
```

This is the only place in `proxy.mjs` that takes a socket out of the server's hands, so no other path needs the same guard.

## Test

Adds one regression test to `test/proxy.test.mjs`. It opens a raw socket, sends an upgrade request, and resets it with `resetAndDestroy()`, then asserts the server still answers. Under the old code the unhandled `error` event kills the test process, so the failure is unambiguous.

Verified both directions:

- With the handler reverted, the new test fails.
- With the fix, it passed 6/6 consecutive runs — no timing flake.
- Full suite on this branch: `node --test` → 78 pass, 0 fail, 1 skipped. The skip is the pre-existing `proxy re-exec forwards termination` case, which skips on Windows because `child.kill` delivers no catchable signal there.

## Scope

Two files, +33 lines, no behavior change beyond not crashing. It does not touch routing, the catalog, credentials, or the autostart paths.
