### PR TITLE
fix: isolate provider request headers

### DIFF
--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -15,7 +15,7 @@ import {
 } from "./constants.mjs";
 import { createVisionDescriber } from "./vision.mjs";
 
-const FORWARDED_REQUEST_HEADERS = new Set([
+const CHATGPT_FORWARDED_REQUEST_HEADERS = new Set([
   "authorization",
   "chatgpt-account-id",
   "openai-beta",
@@ -24,6 +24,7 @@ const FORWARDED_REQUEST_HEADERS = new Set([
   "session-id",
   "thread-id",
   "user-agent",
+  "version",
   "x-client-request-id",
   "x-codex-beta-features",
   "x-codex-installation-id",
@@ -32,9 +33,15 @@ const FORWARDED_REQUEST_HEADERS = new Set([
   "x-codex-turn-state",
   "x-codex-window-id",
   "x-oai-attestation",
+  "x-openai-fedramp",
+  "x-openai-internal-codex-residency",
+  "x-openai-internal-codex-responses-lite",
+  "x-openai-memgen-request",
   "x-openai-subagent",
   "x-responsesapi-include-timing-metrics",
 ]);
+
+const DEEPSEEK_FORWARDED_REQUEST_HEADERS = new Set(["user-agent"]);
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -395,8 +402,11 @@ function authorizedPath(pathname, routerToken) {
 
 function copyRequestHeaders(request, deepSeekKey) {
   const headers = new Headers();
+  const forwarded = deepSeekKey
+    ? DEEPSEEK_FORWARDED_REQUEST_HEADERS
+    : CHATGPT_FORWARDED_REQUEST_HEADERS;
   for (const [name, value] of Object.entries(request.headers)) {
-    if (!FORWARDED_REQUEST_HEADERS.has(name) || value === undefined) continue;
+    if (!forwarded.has(name) || value === undefined) continue;
     headers.set(name, Array.isArray(value) ? value.join(", ") : value);
   }
   headers.set("content-type", "application/json");

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -278,6 +278,11 @@ test("forwards native GPT models to ChatGPT Codex with OAuth headers", async (t)
       path: request.url,
       authorization: request.headers.authorization,
       account: request.headers["chatgpt-account-id"],
+      fedramp: request.headers["x-openai-fedramp"],
+      memgen: request.headers["x-openai-memgen-request"],
+      residency: request.headers["x-openai-internal-codex-residency"],
+      responsesLite: request.headers["x-openai-internal-codex-responses-lite"],
+      version: request.headers.version,
       body: JSON.parse(await bodyOf(request)),
     };
     response.writeHead(200, { "content-type": "application/json" });
@@ -299,6 +304,11 @@ test("forwards native GPT models to ChatGPT Codex with OAuth headers", async (t)
       "content-type": "application/json",
       authorization: "Bearer oauth-token",
       "chatgpt-account-id": "acct-test",
+      "x-openai-fedramp": "true",
+      "x-openai-memgen-request": "true",
+      "x-openai-internal-codex-residency": "us",
+      "x-openai-internal-codex-responses-lite": "true",
+      version: "0.test",
     },
     body: JSON.stringify(original),
   });
@@ -306,7 +316,95 @@ test("forwards native GPT models to ChatGPT Codex with OAuth headers", async (t)
   assert.equal(observed.path, "/backend-api/codex/responses");
   assert.equal(observed.authorization, "Bearer oauth-token");
   assert.equal(observed.account, "acct-test");
+  assert.equal(observed.fedramp, "true");
+  assert.equal(observed.memgen, "true");
+  assert.equal(observed.residency, "us");
+  assert.equal(observed.responsesLite, "true");
+  assert.equal(observed.version, "0.test");
   assert.deepEqual(observed.body, original);
+});
+
+test("forwards Responses Lite to the remote compaction endpoint", async (t) => {
+  let observed;
+  const upstream = http.createServer(async (request, response) => {
+    observed = {
+      path: request.url,
+      responsesLite: request.headers["x-openai-internal-codex-responses-lite"],
+      body: JSON.parse(await bodyOf(request)),
+    };
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end('{"output":[{"type":"compaction_summary","encrypted_content":"opaque"}]}');
+  });
+  const upstreamUrl = await listen(upstream);
+  const proxy = createProxyServer({
+    chatGptBaseUrl: `${upstreamUrl}/backend-api/codex`,
+    logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
+  });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); await close(upstream); });
+
+  const original = { model: "gpt-5.6-sol", input: [{ role: "user", content: "compact me" }] };
+  const response = await fetch(route(proxyUrl, "/v1/responses/compact"), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openai-internal-codex-responses-lite": "true",
+    },
+    body: JSON.stringify(original),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(observed.path, "/backend-api/codex/responses/compact");
+  assert.equal(observed.responsesLite, "true");
+  assert.deepEqual(observed.body, original);
+  assert.deepEqual(await response.json(), {
+    output: [{ type: "compaction_summary", encrypted_content: "opaque" }],
+  });
+});
+
+test("does not forward ChatGPT authentication metadata to DeepSeek", async (t) => {
+  let observed;
+  const upstream = http.createServer(async (request, response) => {
+    observed = { ...request.headers };
+    await bodyOf(request);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("{}");
+  });
+  const upstreamUrl = await listen(upstream);
+  const proxy = createProxyServer({
+    deepSeekKey: "deepseek-test-key",
+    deepSeekBaseUrl: upstreamUrl,
+    logger: { info() {}, error() {} },
+    routerToken: ROUTER_TOKEN,
+  });
+  const proxyUrl = await listen(proxy);
+  t.after(async () => { await close(proxy); await close(upstream); });
+
+  const response = await fetch(route(proxyUrl), {
+    method: "POST",
+    headers: {
+      authorization: "Bearer oauth-token",
+      "chatgpt-account-id": "acct-test",
+      session_id: "session-underscore-test",
+      "session-id": "session-test",
+      "thread-id": "thread-test",
+      "user-agent": "codex-test",
+      "x-oai-attestation": "attestation-test",
+      "x-codex-turn-metadata": "metadata-test",
+    },
+    body: JSON.stringify({ model: "deepseek/deepseek-v4-flash", input: "hello" }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(observed.authorization, "Bearer deepseek-test-key");
+  assert.equal(observed["user-agent"], "codex-test");
+  assert.equal(observed["chatgpt-account-id"], undefined);
+  assert.equal(observed.session_id, undefined);
+  assert.equal(observed["session-id"], undefined);
+  assert.equal(observed["thread-id"], undefined);
+  assert.equal(observed["x-oai-attestation"], undefined);
+  assert.equal(observed["x-codex-turn-metadata"], undefined);
 });
 
 test("keeps pooled loopback connections alive past the Codex client idle timeout", async (t) => {


### PR DESCRIPTION
## Summary

- forward the Responses-Lite and related Codex request headers on GPT passthrough requests
- use separate request-header allowlists for ChatGPT and DeepSeek
- keep ChatGPT account, session, attestation, and Codex installation metadata away from the DeepSeek upstream
- add regression coverage for GPT remote compaction and DeepSeek header isolation

## Root cause

The proxy used one request-header allowlist for both upstream providers.

That allowlist was incomplete for ChatGPT: it dropped `x-openai-internal-codex-responses-lite` and related headers, so GPT `/responses/compact` requests were not interpreted as Responses-Lite remote compaction requests.

At the same time, the shared allowlist was too broad for DeepSeek: it copied ChatGPT account and Codex session metadata before replacing only the `authorization` header with the DeepSeek API key.

## Changes

- add `version`, `x-openai-fedramp`, `x-openai-internal-codex-residency`, `x-openai-internal-codex-responses-lite`, and `x-openai-memgen-request` to the ChatGPT allowlist
- restrict DeepSeek-bound inherited headers to `user-agent`; the proxy continues to set the DeepSeek authorization and protocol headers itself
- verify the `/v1/responses/compact` path and Responses-Lite header end to end
- verify both `session_id` spellings and other ChatGPT/Codex metadata are absent at the DeepSeek upstream while `user-agent` remains available

## Validation

- `node --test test/proxy.test.mjs` — 17/17 passed
- `npm test` — 80/80 passed
- `git diff --check`
- real GPT passthrough `/compact` validation returned HTTP 200 and Codex displayed `Context compacted`

Closes #15
Closes #16

Related: #17 documents the separate DeepSeek-to-GPT reasoning-history compatibility issue; this PR does not rewrite GPT request bodies or claim to fix it.
