### PR TITLE
修复 Windows 路由器自动恢复与 Codex 模型目录兼容性

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,10 @@ The non-negotiable details:
    macOS, systemd user service `dscodex.service` on Linux, Task Scheduler `DSCodex` plus a hidden
    wscript shim on Windows). The generated plist/unit/VBS must never embed the DeepSeek API key —
    the router resolves it from the stored key file at runtime. KeepAlive/Restart only cover
-    crashes: `stop` uses the authenticated shutdown endpoint, the router exits 0 gracefully, and it must stay down. The
+    crashes: the Windows VBS must wait for a hidden supervisor that restarts nonzero router exits, with
+    Task Scheduler restart settings as a second fallback; registration must finish before replacing a healthy
+    manual router, and a failed handoff must restore that router. `stop` uses the authenticated shutdown
+    endpoint, the router exits 0 gracefully, and it must stay down. The
    `serve` process owns `~/.codex/dscodex/server.pid` no matter who launched it, so `stop` works
    for autostarted instances too. `uninstall` must disable autostart and delete the generated
    artifacts.

--- a/README.en.md
+++ b/README.en.md
@@ -68,7 +68,7 @@ Fully quit (⌘Q) and relaunch the ChatGPT app, start a **new** task, and pick `
 node src/cli.mjs key set
 node src/cli.mjs proxy set http://127.0.0.1:10808   # optional
 node src/cli.mjs install && node src/cli.mjs start && node src/cli.mjs doctor
-node src/cli.mjs autostart enable   # optional: start at login
+node src/cli.mjs autostart enable   # optional: start at login and recover router crashes
 ```
 
 CLI default: **High**; add `-c 'model_reasoning_effort="max"'` for **Max**.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm test
 node src/cli.mjs key set
 node src/cli.mjs proxy set http://127.0.0.1:10808   # 可选
 node src/cli.mjs install && node src/cli.mjs start && node src/cli.mjs doctor
-node src/cli.mjs autostart enable   # 可选：登录自启
+node src/cli.mjs autostart enable   # 可选：登录自启；路由崩溃后自动恢复
 ```
 
 CLI 默认 **High**；加 `-c 'model_reasoning_effort="max"'` 使用 **Max**。

--- a/src/autostart.mjs
+++ b/src/autostart.mjs
@@ -4,6 +4,8 @@ import { join, win32 } from "node:path";
 export const LAUNCHD_LABEL = "com.dscodex.router";
 export const SYSTEMD_UNIT = "dscodex.service";
 export const WINDOWS_TASK = "DSCodex";
+export const WINDOWS_RESTART_COUNT = 255;
+export const WINDOWS_RESTART_INTERVAL_MINUTES = 1;
 
 export function autostartKind(platform = process.platform) {
   if (platform === "darwin") return "launchd";
@@ -86,38 +88,67 @@ function psQuote(value) {
   return `'${String(value).replaceAll("'", "''")}'`;
 }
 
-function winQuote(value) {
-  return `"${String(value).replaceAll('"', '\\"')}"`;
+function vbsString(value) {
+  return `"${String(value).replaceAll('"', '""')}"`;
 }
 
-function powershellPath() {
-  return win32.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-}
-
-function psPath(value, homeDir) {
+function vbsPath(value, homeDir) {
   const path = String(value);
   const homePrefix = String(homeDir).replace(/[\\/]+$/, "");
   const lowerPath = path.toLowerCase();
   const lowerHome = homePrefix.toLowerCase();
-  if (homePrefix && lowerPath === lowerHome) return "$env:USERPROFILE";
+  if (homePrefix && lowerPath === lowerHome) {
+    return 'shell.ExpandEnvironmentStrings("%USERPROFILE%")';
+  }
   if (homePrefix && (lowerPath.startsWith(`${lowerHome}\\`) || lowerPath.startsWith(`${lowerHome}/`))) {
     // wscript reads generated .vbs files through the active ANSI code page.
     // Keep non-ASCII user names out of the VBS source and resolve them at run time.
-    return `($env:USERPROFILE + ${psQuote(path.slice(homePrefix.length))})`;
+    return `shell.ExpandEnvironmentStrings("%USERPROFILE%") & ${vbsString(path.slice(homePrefix.length))}`;
   }
-  return psQuote(path);
+  return vbsString(path);
 }
 
-// The task runs wscript.exe on this one-liner so no console window flashes at
-// logon. It deliberately avoids `cmd /c`: a cmd string would need escaping for
-// `&`, `^`, `|`, `<`, `>` etc., so paths (which may contain those characters)
-// are passed to PowerShell as single-quoted arguments instead and the router
-// log is appended with PowerShell's `*>>`.
-export function buildWindowsVbs({ nodePath, cliPath, port, logPath, homeDir = homedir() }) {
+// The task runs wscript.exe on this shim so no console window flashes at logon.
+// VBS waits for the Node supervisor and propagates its exit code. The supervisor
+// owns log redirection and crash restarts; avoiding a Windows PowerShell pipeline
+// is important because PowerShell 5 turns redirected native stderr into a
+// terminating NativeCommandError when ErrorActionPreference is Stop.
+export function buildWindowsVbs({ nodePath, cliPath, port, codexHome = homedir(), homeDir = homedir() }) {
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(`Invalid port: ${port}`);
   }
-  const script = `$ErrorActionPreference='Stop'; & ${psPath(nodePath, homeDir)} ${psPath(cliPath, homeDir)} serve --port ${port} *>> ${psPath(logPath, homeDir)}`;
-  const commandLine = `${winQuote(powershellPath())} -NoProfile -NonInteractive -WindowStyle Hidden -Command ${winQuote(script)}`;
-  return `CreateObject("Wscript.Shell").Run "${commandLine.replaceAll('"', '""')}", 0, False\r\n`;
+  return [
+    'Set shell = CreateObject("Wscript.Shell")',
+    `nodePath = ${vbsPath(nodePath, homeDir)}`,
+    `cliPath = ${vbsPath(cliPath, homeDir)}`,
+    `codexHome = ${vbsPath(codexHome, homeDir)}`,
+    'shell.Environment("Process")("CODEX_HOME") = codexHome',
+    `command = Chr(34) & nodePath & Chr(34) & " " & Chr(34) & cliPath & Chr(34) & " supervise --port ${port}"`,
+    'WScript.Quit shell.Run(command, 0, True)',
+    "",
+  ].join("\r\n");
+}
+
+export function encodeWindowsVbs(source) {
+  // WSH reliably reads UTF-16LE scripts with a BOM. This covers repositories
+  // and custom CODEX_HOME paths containing characters outside the ANSI codepage.
+  return Buffer.from(`\uFEFF${source}`, "utf16le");
+}
+
+// Register through the ScheduledTasks PowerShell module instead of schtasks'
+// CLI-only defaults. The explicit interactive principal scopes the logon
+// trigger to the current user, needs no stored password, and allows a standard
+// user to own the task. RestartOnFailure makes Windows match launchd/systemd.
+export function buildWindowsRegisterScript({ taskName, vbsPath, windowsDir = process.env.SystemRoot ?? "C:\\Windows" }) {
+  const wscript = win32.join(windowsDir, "System32", "wscript.exe");
+  return [
+    "$ErrorActionPreference='Stop'",
+    `$action=New-ScheduledTaskAction -Execute ${psQuote(wscript)} -Argument ${psQuote(`"${vbsPath}"`)}`,
+    "$identity=[System.Security.Principal.WindowsIdentity]::GetCurrent()",
+    "$user=$identity.Name",
+    "$trigger=New-ScheduledTaskTrigger -AtLogOn -User $user",
+    "$principal=New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited",
+    `$settings=New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew -RestartCount ${WINDOWS_RESTART_COUNT} -RestartInterval (New-TimeSpan -Minutes ${WINDOWS_RESTART_INTERVAL_MINUTES}) -StartWhenAvailable`,
+    `Register-ScheduledTask -TaskName ${psQuote(taskName)} -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'DSCodex loopback router' -Force | Out-Null`,
+  ].join("; ");
 }

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -20,6 +20,7 @@ function clone(value) {
 // start). Backfill known-required fields on native entries with safe
 // defaults; the DeepSeek entry sets its own values explicitly.
 const NATIVE_ENTRY_DEFAULTS = {
+  prefer_websockets: false,
   supports_reasoning_summaries: false,
 };
 
@@ -27,6 +28,13 @@ function backfillNativeEntry(model) {
   const entry = clone(model);
   for (const [key, value] of Object.entries(NATIVE_ENTRY_DEFAULTS)) {
     if (entry[key] === undefined) entry[key] = value;
+  }
+  // Codex CLI 0.146+ requires this legacy top-level field even though current
+  // desktop caches carry the same instructions only in model_messages.
+  if (typeof entry.base_instructions !== "string") {
+    entry.base_instructions = typeof entry.model_messages?.instructions_template === "string"
+      ? entry.model_messages.instructions_template
+      : "";
   }
   return entry;
 }
@@ -39,7 +47,7 @@ function replaceIdentity(value, productName) {
 }
 
 export function buildDeepSeekCatalogEntry(template, model = DEEPSEEK_MODELS[0]) {
-  const entry = clone(template);
+  const entry = backfillNativeEntry(template);
   entry.slug = model.pickerSlug;
   entry.display_name = model.displayName;
   entry.description = `${model.productName} via the native Responses API.`;

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -41,6 +41,7 @@ import {
   validateProxyUrl,
 } from "./proxy-config.mjs";
 import { createProxyServer } from "./proxy.mjs";
+import { superviseRouter } from "./supervisor.mjs";
 import {
   LAUNCHD_LABEL,
   SYSTEMD_UNIT,
@@ -48,7 +49,9 @@ import {
   autostartKind,
   buildLaunchdPlist,
   buildSystemdUnit,
+  buildWindowsRegisterScript,
   buildWindowsVbs,
+  encodeWindowsVbs,
   launchdPlistPath,
   systemdUnitPath,
 } from "./autostart.mjs";
@@ -86,6 +89,34 @@ function nodePath() {
     // Fall back to the current interpreter below.
   }
   return process.execPath;
+}
+
+function powershellPath() {
+  return join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+function windowsTaskInfo() {
+  if (process.platform !== "win32") return null;
+  try {
+    const script = [
+      `$task=Get-ScheduledTask -TaskName '${WINDOWS_TASK}' -ErrorAction Stop`,
+      "$info=$task | Get-ScheduledTaskInfo",
+      "[pscustomobject]@{state=[string]$task.State;lastTaskResult=[long]$info.LastTaskResult} | ConvertTo-Json -Compress",
+    ].join("; ");
+    return JSON.parse(execFileSync(powershellPath(), [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      script,
+    ], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }));
+  } catch {
+    return null;
+  }
+}
+
+function windowsTaskResult(value) {
+  if (!Number.isInteger(value)) return "unknown";
+  return `0x${(value >>> 0).toString(16).padStart(8, "0").toUpperCase()}`;
 }
 
 function writeBridgeShim(path) {
@@ -205,6 +236,14 @@ function resolveDeepSeekKey(env = process.env, keyFile = "") {
   return launchctlKey();
 }
 
+function requireProxyRuntime(paths, env = process.env) {
+  const proxyUrl = resolveProxy(env, readProxyUrl(paths.keyFile));
+  if (proxyUrl && !envProxySupported()) {
+    throw new Error(`proxy support requires Node.js >= 24.5 (found ${process.version}); upgrade Node or clear the proxy (proxy clear)`);
+  }
+  return proxyUrl;
+}
+
 function keySource(keyFile, env = process.env) {
   if (env.DEEPSEEK_API_KEY?.trim()) return "environment";
   if (readStoredKey(keyFile)) return `stored in ${keyFile}`;
@@ -301,6 +340,18 @@ function loadModels(paths) {
   return [];
 }
 
+function catalogReady(paths) {
+  try {
+    const models = loadModels(paths);
+    return models.length > 0 && models.every((model) => (
+      typeof model?.slug === "string"
+      && typeof model.base_instructions === "string"
+    ));
+  } catch {
+    return false;
+  }
+}
+
 function tokenValue(value) {
   return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
 }
@@ -352,6 +403,10 @@ function removePidState(paths, expected) {
     renameSync(paths.pid, claimed);
   } catch (error) {
     if (error?.code === "ENOENT") return;
+    // Some managed Windows environments temporarily deny mutations in the
+    // Codex state directory. A stale owner-only pid file is replaced by the
+    // next serve instance; do not turn graceful shutdown into a crash.
+    if (error?.code === "EPERM" || error?.code === "EACCES") return;
     throw error;
   }
   let matches = false;
@@ -362,7 +417,15 @@ function removePidState(paths, expected) {
     // An invalid or replacement state must be restored, not discarded.
   }
   if (matches) {
-    unlinkSync(claimed);
+    try {
+      unlinkSync(claimed);
+    } catch (error) {
+      if (error?.code !== "EPERM" && error?.code !== "EACCES") throw error;
+      // Some managed agent environments intercept deletes and can reject them.
+      // The live pid pathname is already gone; scrub control-plane tokens from
+      // the claimed file and keep graceful shutdown from becoming a crash.
+      try { writeFileSync(claimed, "", { mode: 0o600 }); } catch {}
+    }
     return;
   }
   try {
@@ -371,7 +434,13 @@ function removePidState(paths, expected) {
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
   }
-  unlinkSync(claimed);
+  try {
+    unlinkSync(claimed);
+  } catch (error) {
+    if (error?.code !== "EPERM" && error?.code !== "EACCES") throw error;
+    // If the replacement state was hard-linked above, scrubbing the claimed
+    // name would corrupt the live pid file. Preserve the owner-only duplicate.
+  }
 }
 
 async function serve(port) {
@@ -379,14 +448,7 @@ async function serve(port) {
   const binding = ensureManagedRouterBinding({ paths, port });
   const routerToken = binding.routerToken;
   if (binding.updated) console.log(`${ts()} Updated the managed router URL for the active token and port`);
-  const storedProxy = readProxyUrl(paths.keyFile);
-  const proxyUrl = resolveProxy(process.env, storedProxy);
-  if (proxyUrl && !envProxySupported()) {
-    console.error(`${ts()} dscodex: proxy support requires Node.js >= 24.5 (found ${process.version}); ` +
-      "upgrade Node or clear the proxy (proxy clear)");
-    process.exitCode = 1;
-    return;
-  }
+  const proxyUrl = requireProxyRuntime(paths);
   // Node's fetch ignores proxy env vars unless --use-env-proxy is active.
   // Re-exec ourselves with the flag (and the resolved proxy in the env) so
   // `start`, autostart, and a manual `serve` all behave identically.
@@ -507,6 +569,7 @@ async function start(port) {
     console.log(`DSCodex is already running on ${HOST}:${port}`);
     return;
   }
+  requireProxyRuntime(paths);
   mkdirSync(paths.stateDir, { recursive: true, mode: 0o700 });
   syncIfPossible(paths);
   const logFd = openSync(paths.log, "a", 0o600);
@@ -534,6 +597,65 @@ async function start(port) {
     }
   }
   throw new Error(`DSCodex did not become ready; inspect ${paths.log}`);
+}
+
+async function supervise(port) {
+  const { paths } = runtime();
+  await superviseRouter({
+    nodePath: nodePath(),
+    cliPath: fileURLToPath(import.meta.url),
+    port,
+    logPath: paths.log,
+  });
+}
+
+async function waitForHealth(port, routerToken, attempts = 50) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const ready = await health(port, routerToken);
+    if (ready) return ready;
+  }
+  return null;
+}
+
+async function waitForWindowsTaskState(expected, attempts = 100) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const info = windowsTaskInfo();
+    if (info?.state === expected) return info;
+    // Registration or the previous task instance may still be settling.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Windows task ${WINDOWS_TASK} did not reach state ${expected}`);
+}
+
+async function restoreManualRouter(paths, port, cause, rollback) {
+  const failures = [cause];
+  if (rollback) {
+    try {
+      await rollback();
+    } catch (rollbackError) {
+      failures.push(rollbackError);
+    }
+  }
+  try {
+    await start(port);
+  } catch (restoreError) {
+    failures.push(restoreError);
+    throw new AggregateError(
+      failures,
+      `Autostart failed and the previous manual router could not be restored; inspect ${paths.log}`,
+    );
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(
+      failures,
+      "Autostart failed; the previous manual router was restored, but autostart rollback also failed",
+    );
+  }
+  throw new Error(
+    `Autostart failed; the previous manual router was restored: ${cause instanceof Error ? cause.message : String(cause)}`,
+    { cause },
+  );
 }
 
 async function stop() {
@@ -573,15 +695,91 @@ async function autostartEnable(paths, port) {
   const routerToken = binding.routerToken;
   if (binding.updated) console.log("Updated the managed router URL for the active token and port");
   mkdirSync(paths.stateDir, { recursive: true, mode: 0o700 });
-
-  // Free the port so the manager-launched instance can bind immediately.
-  if (await health(port, routerToken)) {
-    await stopInstance(paths);
-    for (let attempt = 0; attempt < 30 && (await health(port, routerToken)); attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+  requireProxyRuntime(paths);
+  const wasRunning = Boolean(await health(port, routerToken));
+  if (kind === "schtasks") {
+    writeFileSync(file, encodeWindowsVbs(buildWindowsVbs({
+      nodePath: nodePath(),
+      cliPath,
+      port,
+      codexHome: dirname(paths.stateDir),
+    })), { mode: 0o600 });
+    // Register before touching a healthy manual router. A permissions/policy
+    // failure must never turn a failed autostart attempt into an outage.
+    execFileSync(powershellPath(), [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      buildWindowsRegisterScript({ taskName: WINDOWS_TASK, vbsPath: file }),
+    ], { stdio: ["ignore", "ignore", "pipe"] });
+    let manualStopped = false;
+    const rollback = async () => {
+      const failures = [];
+      if (manualStopped) {
+        // A task instance may have started but missed the readiness deadline.
+        // Stop it through the authenticated endpoint before removing its owner.
+        try {
+          await stopInstance(paths);
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      try {
+        execFileSync("schtasks", ["/end", "/tn", WINDOWS_TASK], { stdio: ["ignore", "ignore", "ignore"] });
+      } catch {
+        // The task may never have started.
+      }
+      try {
+        execFileSync("schtasks", ["/delete", "/tn", WINDOWS_TASK, "/f"], { stdio: ["ignore", "ignore", "pipe"] });
+      } catch (error) {
+        failures.push(error);
+      }
+      try {
+        unlinkSync(file);
+      } catch (error) {
+        if (error?.code !== "ENOENT") failures.push(error);
+      }
+      if (failures.length) throw new AggregateError(failures, "Failed to roll back Windows autostart");
+    };
+    try {
+      if (wasRunning) {
+        await stopInstance(paths);
+        manualStopped = true;
+      }
+      // Register-ScheduledTask -Force can replace a definition while an older
+      // task instance is still running. End that stale owner only after a
+      // healthy router has been shut down through its authenticated endpoint.
+      if (windowsTaskInfo()?.state !== "Ready") {
+        try {
+          execFileSync("schtasks", ["/end", "/tn", WINDOWS_TASK], { stdio: ["ignore", "ignore", "pipe"] });
+        } catch {
+          // It may have completed between the state query and /end.
+        }
+      }
+      await waitForWindowsTaskState("Ready");
+      // Take effect now, not only at the next logon.
+      execFileSync("schtasks", ["/run", "/tn", WINDOWS_TASK], { stdio: ["ignore", "ignore", "pipe"] });
+      const ready = await waitForHealth(port, routerToken);
+      if (!ready) throw new Error(`Autostart is installed but the router did not become ready; inspect ${paths.log}`);
+      const task = windowsTaskInfo();
+      if (task?.state !== "Running") {
+        throw new Error(`Router started without a live scheduled supervisor (task state: ${task?.state ?? "missing"})`);
+      }
+      console.log(`DSCodex autostart enabled (${kind}); router running on ${HOST}:${port}`);
+      console.log(`DeepSeek key: ${ready.deepseek_key ? "configured" : "missing (resolves from the stored key at runtime)"}`);
+      return;
+    } catch (error) {
+      if (manualStopped || (wasRunning && !(await health(port, routerToken)))) {
+        return restoreManualRouter(paths, port, error, rollback);
+      }
+      await rollback();
+      throw error;
     }
   }
 
+  // launchd/systemd start the service during registration, so release the port
+  // immediately before handing ownership to the service manager.
+  if (wasRunning) await stopInstance(paths);
   if (kind === "launchd") {
     mkdirSync(dirname(file), { recursive: true });
     writeFileSync(file, buildLaunchdPlist({ nodePath: nodePath(), cliPath, port, logPath: paths.log }), { mode: 0o600 });
@@ -591,13 +789,12 @@ async function autostartEnable(paths, port) {
     } catch {
       // Not loaded yet.
     }
-    execFileSync("/bin/launchctl", ["bootstrap", `gui/${uid}`, file], { stdio: ["ignore", "ignore", "pipe"] });
-  } else if (kind === "schtasks") {
-    writeFileSync(file, buildWindowsVbs({ nodePath: nodePath(), cliPath, port, logPath: paths.log }), { mode: 0o600 });
-    const wscript = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "wscript.exe");
-    execFileSync("schtasks", ["/create", "/tn", WINDOWS_TASK, "/sc", "onlogon", "/rl", "limited", "/f", "/tr", `"${wscript}" "${file}"`], { stdio: ["ignore", "ignore", "pipe"] });
-    // Take effect now, not only at the next logon.
-    execFileSync("schtasks", ["/run", "/tn", WINDOWS_TASK], { stdio: ["ignore", "ignore", "pipe"] });
+    try {
+      execFileSync("/bin/launchctl", ["bootstrap", `gui/${uid}`, file], { stdio: ["ignore", "ignore", "pipe"] });
+    } catch (error) {
+      if (wasRunning) return restoreManualRouter(paths, port, error);
+      throw error;
+    }
   } else {
     mkdirSync(dirname(file), { recursive: true });
     writeFileSync(file, buildSystemdUnit({ nodePath: nodePath(), cliPath, port, logPath: paths.log }), { mode: 0o600 });
@@ -605,26 +802,29 @@ async function autostartEnable(paths, port) {
       execFileSync("systemctl", ["--user", "daemon-reload"], { stdio: ["ignore", "ignore", "pipe"] });
       execFileSync("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT], { stdio: ["ignore", "ignore", "pipe"] });
     } catch (error) {
-      throw new Error(`systemd user service unavailable: ${error instanceof Error ? error.message : String(error)}`);
+      const wrapped = new Error(`systemd user service unavailable: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+      if (wasRunning && !(await health(port, routerToken))) return restoreManualRouter(paths, port, wrapped);
+      throw wrapped;
     }
   }
 
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    const ready = await health(port, routerToken);
-    if (ready) {
-      console.log(`DSCodex autostart enabled (${kind}); router running on ${HOST}:${port}`);
-      console.log(`DeepSeek key: ${ready.deepseek_key ? "configured" : "missing (resolves from the stored key at runtime)"}`);
-      return;
-    }
+  const ready = await waitForHealth(port, routerToken);
+  if (ready) {
+    console.log(`DSCodex autostart enabled (${kind}); router running on ${HOST}:${port}`);
+    console.log(`DeepSeek key: ${ready.deepseek_key ? "configured" : "missing (resolves from the stored key at runtime)"}`);
+    return;
   }
-  throw new Error(`Autostart is installed but the router did not become ready; inspect ${paths.log}`);
+  const error = new Error(`Autostart is installed but the router did not become ready; inspect ${paths.log}`);
+  if (wasRunning) return restoreManualRouter(paths, port, error);
+  throw error;
 }
 
-function autostartDisable(paths, { quiet = false } = {}) {
+async function autostartDisable(paths, { quiet = false } = {}) {
   const kind = autostartKind();
   const file = autostartFile(paths);
+  const wasEnabled = autostartEnabled(paths);
   let removed = false;
+  if (wasEnabled) await stopInstance(paths);
   if (kind === "launchd") {
     try {
       execFileSync("/bin/launchctl", ["bootout", `gui/${process.getuid()}/${LAUNCHD_LABEL}`], { stdio: ["ignore", "ignore", "ignore"] });
@@ -633,6 +833,11 @@ function autostartDisable(paths, { quiet = false } = {}) {
       // Not loaded.
     }
   } else if (kind === "schtasks") {
+    try {
+      execFileSync("schtasks", ["/end", "/tn", WINDOWS_TASK], { stdio: ["ignore", "ignore", "ignore"] });
+    } catch {
+      // Task absent or already stopped.
+    }
     try {
       execFileSync("schtasks", ["/delete", "/tn", WINDOWS_TASK, "/f"], { stdio: ["ignore", "ignore", "ignore"] });
       removed = true;
@@ -669,9 +874,16 @@ async function autostartStatus(paths, port) {
   const kind = autostartKind();
   const enabled = autostartEnabled(paths);
   const ready = await health(port, readRouterToken(paths.keyFile));
-  console.log(`autostart: ${enabled ? `enabled (${kind}, port in config: see ${autostartFile(paths)})` : "not enabled"}`);
+  const task = kind === "schtasks" && enabled ? windowsTaskInfo() : null;
+  const taskStatus = task
+    ? `; task ${task.state}${task.state === "Running" ? "" : `, last result ${windowsTaskResult(task.lastTaskResult)}`}`
+    : "";
+  console.log(`autostart: ${enabled ? `enabled (${kind}${taskStatus}, port in config: see ${autostartFile(paths)})` : "not enabled"}`);
   console.log(`router: ${ready ? `running (${HOST}:${port})` : "stopped"}`);
-  if (!enabled) process.exitCode = 1;
+  if (enabled && ready && kind === "schtasks" && task?.state !== "Running") {
+    console.log("warning: the router is running manually; the scheduled supervisor is inactive");
+  }
+  if (!enabled || !ready || (kind === "schtasks" && task?.state !== "Running")) process.exitCode = 1;
 }
 
 async function manageAutostart(subcommand, paths, port) {
@@ -750,7 +962,7 @@ async function doctor(port) {
       catalogPath: paths.catalog,
       routerToken,
     }),
-    catalog_present: existsSync(paths.catalog),
+    catalog_present: existsSync(paths.catalog) && catalogReady(paths),
     router_token_present: Boolean(routerToken),
     proxy_running: Boolean(ready),
     deepseek_key_in_proxy: Boolean(ready?.deepseek_key),
@@ -827,13 +1039,14 @@ async function main() {
     case "proxy": await manageProxy(args[0] ?? "status", args.slice(1), paths, port); break;
     case "start": await start(port); break;
     case "serve": await serve(port); break;
+    case "supervise": await supervise(port); break;
     case "autostart": await manageAutostart(args[0] ?? "status", paths, port); break;
     case "bridge": await manageBridge(args[0] ?? "status", paths); break;
     case "status": await status(port); break;
     case "doctor": await doctor(port); break;
     case "stop": await stop(); break;
     case "uninstall":
-      autostartDisable(paths, { quiet: true });
+      await autostartDisable(paths, { quiet: true });
       await stop();
       uninstall({ paths });
       deactivateBridge(paths);

--- a/src/supervisor.mjs
+++ b/src/supervisor.mjs
@@ -1,0 +1,83 @@
+import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { dirname } from "node:path";
+
+export const SUPERVISOR_RESTART_DELAY_MS = 2_000;
+
+function appendSupervisorLog(fd, message) {
+  try {
+    writeSync(fd, `${new Date().toISOString()} supervisor: ${message}\n`);
+  } catch {
+    // A logging failure must not take down the process that keeps the router alive.
+  }
+}
+
+function childExit(child) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    child.once("error", (error) => finish({ code: null, signal: null, error }));
+    child.once("exit", (code, signal) => finish({ code, signal, error: null }));
+  });
+}
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+// Windows Task Scheduler launches this long-lived process through a hidden VBS
+// shim. Router stdout/stderr go straight to the log descriptor, so ordinary
+// stderr output can never be mistaken for a supervisor failure. Exit 0 is the
+// authenticated `dscodex stop` path and intentionally stops the loop; crashes
+// and spawn failures are retried.
+export async function superviseRouter({
+  nodePath,
+  cliPath,
+  port,
+  logPath,
+  env = process.env,
+  restartDelayMs = SUPERVISOR_RESTART_DELAY_MS,
+}) {
+  if (!nodePath || !cliPath || !logPath) throw new Error("Supervisor paths are required");
+  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error(`Invalid port: ${port}`);
+  if (!Number.isInteger(restartDelayMs) || restartDelayMs < 0) {
+    throw new Error(`Invalid restart delay: ${restartDelayMs}`);
+  }
+
+  mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
+  const logFd = openSync(logPath, "a", 0o600);
+  const childEnv = { ...env };
+  // Every supervised launch is a fresh top-level serve. Let it resolve the
+  // stored proxy and perform its own --use-env-proxy re-exec when required.
+  delete childEnv.DSCODEX_PROXY_REEXEC;
+
+  try {
+    appendSupervisorLog(logFd, `started (node ${process.version}, port ${port})`);
+    while (true) {
+      const child = spawn(nodePath, [cliPath, "serve", "--port", String(port)], {
+        env: childEnv,
+        stdio: ["ignore", logFd, logFd],
+        windowsHide: true,
+      });
+      const result = await childExit(child);
+      if (!result.error && result.code === 0 && !result.signal) {
+        appendSupervisorLog(logFd, "router exited cleanly; staying stopped");
+        return;
+      }
+
+      const detail = result.error
+        ? `spawn failed: ${result.error.message}`
+        : result.signal
+          ? `router exited on ${result.signal}`
+          : `router exited with code ${result.code}`;
+      appendSupervisorLog(logFd, `${detail}; restarting in ${restartDelayMs}ms`);
+      await wait(restartDelayMs);
+    }
+  } finally {
+    closeSync(logFd);
+  }
+}

--- a/test/autostart.test.mjs
+++ b/test/autostart.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { createServer } from "node:http";
@@ -11,13 +11,27 @@ import { fileURLToPath } from "node:url";
 import {
   buildLaunchdPlist,
   buildSystemdUnit,
+  buildWindowsRegisterScript,
   buildWindowsVbs,
+  encodeWindowsVbs,
 } from "../src/autostart.mjs";
 import { buildInstalledConfig } from "../src/config.mjs";
 import { pathsFor } from "../src/constants.mjs";
 import { ensureRouterToken } from "../src/keys.mjs";
 
 const CLI = fileURLToPath(new URL("../src/cli.mjs", import.meta.url));
+const SUPERVISOR_FIXTURE_SOURCE = [
+  'import { readFileSync, writeFileSync } from "node:fs";',
+  'const statePath = process.env.DSCODEX_TEST_SUPERVISOR_STATE;',
+  'let attempts = 0;',
+  'try { attempts = Number(readFileSync(statePath, "utf8")) || 0; } catch {}',
+  'attempts += 1;',
+  'writeFileSync(statePath, String(attempts));',
+  'console.error(`fixture stderr attempt ${attempts}`);',
+  'const failures = Number(process.env.DSCODEX_TEST_SUPERVISOR_FAILURES ?? 0);',
+  'process.exit(attempts <= failures ? 23 : 0);',
+  '',
+].join("\n");
 
 function routerEnv(codexHome, source = process.env) {
   const env = { ...source, CODEX_HOME: codexHome };
@@ -120,18 +134,39 @@ test("systemd unit quotes paths and restarts on failure only", () => {
   assert.ok(unit.includes("StandardOutput=append:/u/.codex/dscodex/server.log"));
 });
 
-test("windows vbs hides the console via PowerShell and quotes paths safely", () => {
+test("windows vbs waits for the hidden Node supervisor and quotes paths safely", () => {
   const vbs = buildWindowsVbs({
     nodePath: "C:\\Program Files\\nodejs\\node.exe",
     cliPath: "C:\\x\\src\\cli.mjs",
     port: 10110,
-    logPath: "C:\\u\\server.log",
+    codexHome: "C:\\u\\.codex",
+    homeDir: "C:\\Users\\tester",
   });
-  assert.match(vbs, /CreateObject\("Wscript\.Shell"\)\.Run ""?[^\r\n]*System32\\WindowsPowerShell\\v1\.0\\powershell\.exe/);
-  assert.ok(vbs.includes("& 'C:\\Program Files\\nodejs\\node.exe' 'C:\\x\\src\\cli.mjs' serve --port 10110 *>> 'C:\\u\\server.log'"));
-  assert.ok(vbs.includes("serve --port 10110"));
-  assert.ok(vbs.trimEnd().endsWith('"", 0, False'));
+  assert.ok(vbs.includes('Set shell = CreateObject("Wscript.Shell")'));
+  assert.ok(vbs.includes('nodePath = "C:\\Program Files\\nodejs\\node.exe"'));
+  assert.ok(vbs.includes('cliPath = "C:\\x\\src\\cli.mjs"'));
+  assert.ok(vbs.includes('codexHome = "C:\\u\\.codex"'));
+  assert.ok(vbs.includes('" supervise --port 10110"'));
+  assert.ok(vbs.includes("WScript.Quit shell.Run(command, 0, True)"));
+  assert.ok(!vbs.includes("powershell"));
+  assert.ok(!vbs.includes("Out-File"));
   assert.ok(!vbs.includes("cmd /c"));
+});
+
+test("windows task registration is user-scoped and restarts router crashes", () => {
+  const script = buildWindowsRegisterScript({
+    taskName: "DSCodex",
+    vbsPath: "C:\\Users\\o'h\\.codex\\dscodex\\autostart-run.vbs",
+    windowsDir: "C:\\Windows",
+  });
+  assert.ok(script.includes("New-ScheduledTaskTrigger -AtLogOn -User $user"));
+  assert.ok(script.includes("New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited"));
+  assert.ok(script.includes("-RestartCount 255"));
+  assert.ok(script.includes("-RestartInterval (New-TimeSpan -Minutes 1)"));
+  assert.ok(script.includes("-ExecutionTimeLimit ([TimeSpan]::Zero)"));
+  assert.ok(script.includes("-MultipleInstances IgnoreNew"));
+  assert.ok(script.includes("Register-ScheduledTask -TaskName 'DSCodex'"));
+  assert.ok(script.includes("'\"C:\\Users\\o''h\\.codex\\dscodex\\autostart-run.vbs\"'"));
 });
 
 test("windows vbs escapes single quotes and is immune to cmd metacharacters in paths", () => {
@@ -139,17 +174,18 @@ test("windows vbs escapes single quotes and is immune to cmd metacharacters in p
     nodePath: "C:\\a&b\\node.exe",
     cliPath: "C:\\o'h\\cli.mjs",
     port: 10110,
-    logPath: "C:\\u|v\\server.log",
+    codexHome: "C:\\u|v\\.codex",
+    homeDir: "C:\\Users\\tester",
   });
-  assert.ok(vbs.includes("'C:\\a&b\\node.exe'"));
-  assert.ok(vbs.includes("'C:\\o''h\\cli.mjs'"));
-  assert.ok(vbs.includes("'C:\\u|v\\server.log'"));
+  assert.ok(vbs.includes('nodePath = "C:\\a&b\\node.exe"'));
+  assert.ok(vbs.includes('cliPath = "C:\\o\'h\\cli.mjs"'));
+  assert.ok(vbs.includes('codexHome = "C:\\u|v\\.codex"'));
   assert.ok(!vbs.includes("cmd /c"));
 });
 
 test("windows vbs rejects invalid ports", () => {
   assert.throws(
-    () => buildWindowsVbs({ nodePath: "n", cliPath: "c", port: 99999, logPath: "l" }),
+    () => buildWindowsVbs({ nodePath: "n", cliPath: "c", port: 99999, codexHome: "h" }),
     /Invalid port/,
   );
 });
@@ -170,23 +206,87 @@ test("windows vbs resolves home-relative paths at runtime for non-ASCII homes", 
     nodePath: "C:\\Program Files\\nodejs\\node.exe",
     cliPath: "C:\\Users\\王小明\\DSCodex\\src\\cli.mjs",
     port: 10110,
-    logPath: "C:\\Users\\王小明\\.codex\\dscodex\\server.log",
+    codexHome: "C:\\Users\\王小明\\.codex",
     homeDir: "C:\\Users\\王小明",
   });
-  assert.ok(vbs.includes("$env:USERPROFILE + '\\DSCodex\\src\\cli.mjs'"));
-  assert.ok(vbs.includes("$env:USERPROFILE + '\\.codex\\dscodex\\server.log'"));
+  assert.ok(vbs.includes('shell.ExpandEnvironmentStrings("%USERPROFILE%") & "\\DSCodex\\src\\cli.mjs"'));
+  assert.ok(vbs.includes('shell.ExpandEnvironmentStrings("%USERPROFILE%") & "\\.codex"'));
   assert.equal(vbs.match(/[^\x00-\x7F]/g), null);
 });
 
-test("windows vbs keeps literal log paths outside the user home", () => {
+test("windows vbs keeps literal Codex homes outside the user home", () => {
   const vbs = buildWindowsVbs({
     nodePath: "C:\\Program Files\\nodejs\\node.exe",
     cliPath: "C:\\x\\src\\cli.mjs",
     port: 10110,
-    logPath: "D:\\logs\\server.log",
+    codexHome: "D:\\state\\.codex",
     homeDir: "C:\\Users\\王小明",
   });
-  assert.ok(vbs.includes("*>> 'D:\\logs\\server.log'"));
+  assert.ok(vbs.includes('codexHome = "D:\\state\\.codex"'));
+});
+
+test("windows vbs is executable and propagates the hidden supervisor exit code", {
+  skip: process.platform !== "win32" ? "Windows integration test" : false,
+}, () => {
+  const temp = mkdtempSync(join(tmpdir(), "dscodex-vbs-"));
+  const vbsPath = join(temp, "autostart-run.vbs");
+  const unicodeDir = join(temp, "测试目录");
+  const fixturePath = join(unicodeDir, "supervisor-child.mjs");
+  const statePath = join(temp, "attempts.txt");
+  try {
+    mkdirSync(unicodeDir);
+    writeFileSync(fixturePath, SUPERVISOR_FIXTURE_SOURCE);
+    writeFileSync(vbsPath, encodeWindowsVbs(buildWindowsVbs({
+      nodePath: process.execPath,
+      cliPath: fixturePath,
+      port: 10110,
+      codexHome: temp,
+    })));
+    const result = spawnSync("cscript.exe", ["//nologo", vbsPath], {
+      env: {
+        ...process.env,
+        DSCODEX_TEST_SUPERVISOR_STATE: statePath,
+        DSCODEX_TEST_SUPERVISOR_FAILURES: "1",
+      },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    assert.equal(result.status, 23, `${result.stdout}\n${result.stderr}`);
+    assert.equal(readFileSync(statePath, "utf8"), "1");
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("failed Windows autostart registration leaves a healthy manual router running", {
+  timeout: 20_000,
+  skip: process.platform !== "win32" ? "Windows integration test" : false,
+}, async () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-autostart-register-fail-"));
+  const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const env = routerEnv(codexHome);
+  const child = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
+    env,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  try {
+    await waitForFile(paths.pid, "router pid file");
+    const failed = await runCli(["autostart", "enable", "--port", String(port)], {
+      ...env,
+      SystemRoot: "C:\\dscodex-missing-windows-root",
+    });
+    assert.notEqual(failed.code, 0, `${failed.stdout}\n${failed.stderr}`);
+
+    const status = await runCli(["status", "--port", String(port)], env);
+    assert.equal(status.code, 0, `${status.stdout}\n${status.stderr}`);
+    assert.match(status.stdout, /running/);
+    assert.equal(JSON.parse(readFileSync(paths.pid, "utf8")).pid, child.pid);
+  } finally {
+    await runCli(["stop", "--port", String(port)], env);
+    child.kill("SIGKILL");
+    rmSync(codexHome, { recursive: true, force: true });
+  }
 });
 
 test("serve owns its pid file across start and graceful shutdown", { timeout: 20_000 }, async () => {
@@ -367,6 +467,92 @@ test("stop preserves pid state written by a replacement instance", { timeout: 20
     heldSocket?.destroy();
     child.kill("SIGKILL");
     stopper?.kill("SIGKILL");
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("graceful shutdown survives a managed environment rejecting pid-state deletion", { timeout: 20_000 }, async () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-stop-delete-hook-"));
+  const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const hook = join(codexHome, "reject-unlink.cjs");
+  writeFileSync(hook, [
+    'const fs = require("node:fs");',
+    'const original = fs.unlinkSync;',
+    'fs.unlinkSync = function(path) {',
+    '  if (String(path).includes("server.pid.remove-")) {',
+    '    const error = new Error("managed delete rejected");',
+    '    error.code = "EPERM";',
+    '    throw error;',
+    '  }',
+    '  return original.apply(this, arguments);',
+    '};',
+    "",
+  ].join("\n"));
+  const env = {
+    ...routerEnv(codexHome),
+    NODE_OPTIONS: `--require=${hook}`,
+  };
+  const child = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
+    env,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const exited = once(child, "exit");
+  try {
+    await waitForFile(paths.pid, "router pid file");
+    const stopped = await runCli(["stop", "--port", String(port)], env);
+    assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
+    const [code] = await exited;
+    assert.equal(code, 0);
+    assert.equal(existsSync(paths.pid), false);
+    const leftovers = await import("node:fs").then(({ readdirSync }) => readdirSync(paths.stateDir));
+    const claimed = leftovers.find((name) => name.startsWith("server.pid.remove-"));
+    assert.ok(claimed);
+    assert.equal(readFileSync(join(paths.stateDir, claimed), "utf8"), "");
+    unlinkSync(join(paths.stateDir, claimed));
+  } finally {
+    child.kill("SIGKILL");
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("graceful shutdown survives a managed environment rejecting the pid-state claim", { timeout: 20_000 }, async () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "dscodex-stop-rename-hook-"));
+  const port = 20_000 + Math.floor(Math.random() * 20_000);
+  const paths = prepareRouterHome(codexHome, port);
+  const hook = join(codexHome, "reject-rename.cjs");
+  writeFileSync(hook, [
+    'const fs = require("node:fs");',
+    'const original = fs.renameSync;',
+    'fs.renameSync = function(source, destination) {',
+    '  if (String(destination).includes("server.pid.remove-")) {',
+    '    const error = new Error("managed rename rejected");',
+    '    error.code = "EPERM";',
+    '    throw error;',
+    '  }',
+    '  return original.apply(this, arguments);',
+    '};',
+    "",
+  ].join("\n"));
+  const env = {
+    ...routerEnv(codexHome),
+    NODE_OPTIONS: `--require=${hook}`,
+  };
+  const child = spawn(process.execPath, [CLI, "serve", "--port", String(port)], {
+    env,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const exited = once(child, "exit");
+  try {
+    await waitForFile(paths.pid, "router pid file");
+    const stopped = await runCli(["stop", "--port", String(port)], env);
+    assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
+    const [code] = await exited;
+    assert.equal(code, 0);
+    assert.equal(existsSync(paths.pid), true);
+    assert.equal(JSON.parse(readFileSync(paths.pid, "utf8")).pid, child.pid);
+  } finally {
+    child.kill("SIGKILL");
     rmSync(codexHome, { recursive: true, force: true });
   }
 });

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -39,11 +39,16 @@ test("runtime version matches package metadata", () => {
 });
 
 test("catalog backfills newly required fields on stale native cache entries", () => {
-  const catalog = buildCatalog({ models: [TEMPLATE] });
+  const staleTemplate = { ...TEMPLATE };
+  delete staleTemplate.base_instructions;
+  const catalog = buildCatalog({ models: [staleTemplate] });
   const native = catalog.models.find((model) => model.slug === "gpt-5.6-sol");
   assert.equal(native.supports_reasoning_summaries, false);
+  assert.equal(native.prefer_websockets, false);
+  assert.equal(native.base_instructions, TEMPLATE.model_messages.instructions_template);
   const deepseek = catalog.models.find((model) => model.slug === "deepseek/deepseek-v4-flash");
   assert.equal(deepseek.supports_reasoning_summaries, false);
+  assert.equal(deepseek.base_instructions, "You are Codex, powered by DeepSeek V4 Flash.");
 });
 
 test("catalog adds distinct whale-labelled V4 Flash and Pro entries", () => {

--- a/test/supervisor.test.mjs
+++ b/test/supervisor.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { superviseRouter } from "../src/supervisor.mjs";
+
+const FIXTURE_SOURCE = [
+  'import { readFileSync, writeFileSync } from "node:fs";',
+  'const statePath = process.env.DSCODEX_TEST_SUPERVISOR_STATE;',
+  'let attempts = 0;',
+  'try { attempts = Number(readFileSync(statePath, "utf8")) || 0; } catch {}',
+  'attempts += 1;',
+  'writeFileSync(statePath, String(attempts));',
+  'console.error(`fixture stderr attempt ${attempts}`);',
+  'const failures = Number(process.env.DSCODEX_TEST_SUPERVISOR_FAILURES ?? 0);',
+  'process.exit(attempts <= failures ? 23 : 0);',
+  '',
+].join("\n");
+
+test("supervisor logs stderr, restarts nonzero exits, and stops on exit zero", async () => {
+  const temp = mkdtempSync(join(tmpdir(), "dscodex-supervisor-"));
+  const fixturePath = join(temp, "supervisor-child.mjs");
+  const statePath = join(temp, "attempts.txt");
+  const logPath = join(temp, "server.log");
+  try {
+    writeFileSync(fixturePath, FIXTURE_SOURCE);
+    await superviseRouter({
+      nodePath: process.execPath,
+      cliPath: fixturePath,
+      port: 10110,
+      logPath,
+      restartDelayMs: 10,
+      env: {
+        ...process.env,
+        DSCODEX_TEST_SUPERVISOR_STATE: statePath,
+        DSCODEX_TEST_SUPERVISOR_FAILURES: "2",
+        DSCODEX_PROXY_REEXEC: "1",
+      },
+    });
+
+    assert.equal(readFileSync(statePath, "utf8"), "3");
+    const log = readFileSync(logPath, "utf8");
+    assert.match(log, /fixture stderr attempt 1/);
+    assert.match(log, /router exited with code 23; restarting/);
+    assert.match(log, /router exited cleanly; staying stopped/);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 背景

Windows 计划任务虽然已注册，但旧实现把路由输出接入 Windows PowerShell 5 管道；原生进程只要写入 stderr，PowerShell 就可能抛出 `NativeCommandError` 并结束整个守护循环，最终导致本地 10110 无监听和桌面端 502。

同时，新版 Codex CLI 对模型目录字段有更严格要求，需要补齐原生模型条目，并明确让本地路由使用 HTTP/SSE 回退。

## 主要改动

- 新增独立 Node supervisor：路由异常退出时自动重启，认证停止产生的零退出则保持停止。
- Windows VBS 仅负责隐藏窗口并等待 supervisor，不再通过 PowerShell 管道转发日志。
- VBS 使用带 BOM 的 UTF-16LE，兼容中文用户名、仓库路径和自定义 `CODEX_HOME`。
- 计划任务配置无限执行时间、登录触发和失败重试，并在接管前完成注册；交接失败时恢复原有健康路由。
- `autostart status` 会同时检查任务状态与路由健康，识别“任务已注册但仅有手工路由运行”的假健康状态。
- 加固 PID 状态清理、认证停止、代理运行时检查和目录完整性检查。
- 模型目录声明 `prefer_websockets = false`，并为旧缓存条目补齐 `base_instructions`。
- 更新中英文说明及 Windows、supervisor、配置回归测试。

## 验证

- `npm test`：86 项通过，0 项失败，1 项按 Windows 平台条件跳过。
- 生成的 VBS 已通过 `cscript.exe` 真实执行，并正确回传 supervisor 退出码。
- 强制结束已核验的路由进程后，supervisor 能自动生成新进程并恢复 10110。
- 认证 `stop` 后计划任务以零状态结束，等待后不会擅自复活。
- 原生 GPT 已完成一次真实 shell 工具回路，HTTP/SSE 回退正常，无 502。

